### PR TITLE
ACCUMULO-4721 (v2.0) Document rfile-info in user manual

### DIFF
--- a/_docs-2-0/troubleshooting/basic.md
+++ b/_docs-2-0/troubleshooting/basic.md
@@ -132,10 +132,10 @@ Do you have your auths set so that it matches your visibilities?
 
 **What are my visibilities?**
 
-Use the [PrintInfo][print-info] tool on a representative file to get some idea
+Use the [rfile-info][RFileInfo] tool on a representative file to get some idea
 of the visibilities in the underlying data.
 
-Note that the use of `PrintInfo` is an administrative tool and can only
+Note that the use of `rfile-info` is an administrative tool and can only
 by used by someone who can access the underlying Accumulo data. It
 does not provide the normal access controls in Accumulo.
 
@@ -231,5 +231,5 @@ Node count: 22524
 
 Check zookeeper status, verify that it has a quorum, and has not exceeded maxClientCnxns.
 
-[print-info]: {{ page.docs_baseurl }}/troubleshooting/tools#PrintInfo
+[rfile-info]: {{ page.docs_baseurl }}/troubleshooting/tools#RFileInfo
 [native-maps]: {{ page.docs_baseurl }}/administration/in-depth-install#native-map

--- a/_docs-2-0/troubleshooting/basic.md
+++ b/_docs-2-0/troubleshooting/basic.md
@@ -132,7 +132,7 @@ Do you have your auths set so that it matches your visibilities?
 
 **What are my visibilities?**
 
-Use the [rfile-info][RFileInfo] tool on a representative file to get some idea
+Use the [rfile-info] tool on a representative file to get some idea
 of the visibilities in the underlying data.
 
 Note that the use of `rfile-info` is an administrative tool and can only

--- a/_docs-2-0/troubleshooting/tools.md
+++ b/_docs-2-0/troubleshooting/tools.md
@@ -4,14 +4,14 @@ category: troubleshooting
 order: 3
 ---
 
-The `accumulo` command can be used to run classes from the command line.
+The `accumulo` command can be used to run various tools and classes from the command line.
 
-## PrintInfo
+## RFileInfo
 
-The `PrintInfo` tool will examine an Accumulo storage file and print out basic metadata.
+The `rfile-info` tool will examine an Accumulo storage file and print out basic metadata.
 
 ```
-$ accumulo org.apache.accumulo.core.file.rfile.PrintInfo /accumulo/tables/1/default_tablet/A000000n.rf
+$ accumulo rfile-info /accumulo/tables/1/default_tablet/A000000n.rf
 2013-07-16 08:17:14,778 [util.NativeCodeLoader] INFO : Loaded the native-hadoop library
 Locality group         : <DEFAULT>
         Start block          : 0
@@ -37,9 +37,9 @@ Meta block     : RFile.index
       Compression type     : gz
 ```
 
-When trying to diagnose problems related to key size, the `PrintInfo` tool can provide a histogram of the individual key sizes:
+When trying to diagnose problems related to key size, the `rfile-info` tool can provide a histogram of the individual key sizes:
 
-    $ accumulo org.apache.accumulo.core.file.rfile.PrintInfo --histogram /accumulo/tables/1/default_tablet/A000000n.rf
+    $ accumulo rfile-info --histogram /accumulo/tables/1/default_tablet/A000000n.rf
     ...
     Up to size      count      %-age
              10 :        222  28.23%
@@ -53,9 +53,9 @@ When trying to diagnose problems related to key size, the `PrintInfo` tool can p
      1000000000 :          0   0.00%
     10000000000 :          0   0.00%
 
-Likewise, `PrintInfo` will dump the key-value pairs and show you the contents of the RFile:
+Likewise, `rfile-info` will dump the key-value pairs and show you the contents of the RFile:
 
-    $ accumulo org.apache.accumulo.core.file.rfile.PrintInfo --dump /accumulo/tables/1/default_tablet/A000000n.rf
+    $ accumulo rfile-info --dump /accumulo/tables/1/default_tablet/A000000n.rf
     row columnFamily:columnQualifier [visibility] timestamp deleteFlag -> Value
     ...
 


### PR DESCRIPTION
ACCUMULO-4721 Document rfile-info in user manual

Updated the accumulo-website repository documentation for release 2.0 to reference rfile-info rather
than org.apache.accumulo.core.file.rfile.PrintInfo. Should be easier to uderstand for a user than the longer classname.

Note: Although I believe I made the appropriate changes necessary, I was not able to verify the change using Jekyll as I'm having issues getting it to run on my local workstation.  If someone is willing to verify it would be greatly appreciated.