### PR TITLE
Fix small typo on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,9 +15,9 @@ skiph1fortitle: true
     <h3>Major Features</h3>
 
     <div class="row">
-      <div class="col-md-6"> 
+      <div class="col-md-6">
         <h4>Server-side programming</h4>
-        <p>Accumulo has a programing meachinism (called <a href="{{ site.docs_baseurl }}/development/iterators">Iterators</a>) that can modify key/value pairs at various points in the data management process.</p>
+        <p>Accumulo has a programming mechanism (called <a href="{{ site.docs_baseurl }}/development/iterators">Iterators</a>) that can modify key/value pairs at various points in the data management process.</p>
       </div>
       <div class="col-md-6">
         <h4>Cell-based access control</h4>
@@ -25,7 +25,7 @@ skiph1fortitle: true
       </div>
     </div>
     <div class="row">
-      <div class="col-md-6"> 
+      <div class="col-md-6">
         <h4>Designed to scale</h4>
         <p>Accumulo runs on a cluster using <a href="{{ site.docs_baseurl }}/administration/multivolume">one or more HDFS instances</a>. Nodes can be added or removed as the amount of data stored in Accumulo changes.</p>
       </div>


### PR DESCRIPTION
"programing meachinism" -> "programming mechanism"