### PR TITLE
Update monitoring-metrics.md

### DIFF
--- a/_docs-2/administration/monitoring-metrics.md
+++ b/_docs-2/administration/monitoring-metrics.md
@@ -74,14 +74,7 @@ An Accumulo user name and password must be entered for access to the shell.
 
 ## Metrics
 
-Accumulo can expose metrics through a legacy metrics library and using the Hadoop Metrics2 library.
-
-### Legacy Metrics
-
-Accumulo has a legacy metrics library that can be exposes metrics using JMX endpoints or file-based logging. These metrics can
-be enabled by setting {% plink general.legacy.metrics %} to `true` in `accumulo.properties` and placing the `accumulo-metrics.xml`
-configuration file on the classpath (which is typically done by placing the file in the `conf/` directory). A template for
-`accumulo-metrics.xml` can be found in `conf/templates` of the Accumulo tarball.
+Accumulo can expose metrics using the Hadoop Metrics2 library.
 
 ### Hadoop Metrics2
 


### PR DESCRIPTION
If my understanding is correct, the legacy metrics paragraph appears to be outdated for 2.x. It refers to properties that do not appear in 2.x and points the reader to an accumulo-metrics.xml file that is not included in the 2.x tarball. This update removes the paragraph from the 2.x documentation. 