### PR TITLE
Improve the LTM wording

### DIFF
--- a/contributor/versioning.md
+++ b/contributor/versioning.md
@@ -30,7 +30,7 @@ Goals of the LTM strategy:
 
 Note: the above strategy is a declaration of **intent** only. We use the term
 "Long Term Maintenance" rather than the more familiar "Long Term Support" or
-"Long Term Stable" terms to avoid confusion over the implication of warranties
+"Long Term Stable" terms to avoid any implication of warranties
 from the use of the words "support" or "stable". See the project LICENSE for a full
 disclaimer of warranties. If you have questions, about this, please [contact] us.
 

--- a/contributor/versioning.md
+++ b/contributor/versioning.md
@@ -8,7 +8,7 @@ redirect_from: /versioning
 
 The Apache Accumulo PMC has adopted a Long Term Maintenance (LTM) release strategy.
 
-This strategy entails an intent to:
+### LTM Versions:
 
 1. Periodically release a new LTM `major.minor.0` version (approximately every 2 years),
 2. Maintain the LTM releases with `major.minor.(patch++)` releases until 1 year after the next LTM,
@@ -17,12 +17,12 @@ This strategy entails an intent to:
 This strategy implies that no more than one or two LTM releases will be
 actively maintained at any given time, with one year of overlap.
 
-Non-LTM versions:
+### Non-LTM versions:
 
 1. Release intermediate non-LTM `major.minor.0` versions that are not expected to receive patch/bugfix releases,
 2. Roll patches/bugfixes targeting non-LTM versions into the next `major.minor.0` release
 
-Goals of the LTM strategy:
+### Goals of the LTM strategy:
 - Streamline maintaining multiple versions of Accumulo
 - Encourage development on newer versions
 - Provide greater confidence for users to upgrade and receive updates (within one year)

--- a/contributor/versioning.md
+++ b/contributor/versioning.md
@@ -12,25 +12,27 @@ This strategy entails an intent to:
 
 1. Periodically release a new LTM `major.minor.0` version (approximately every 2 years),
 2. Maintain the LTM releases with `major.minor.(patch++)` releases until 1 year after the next LTM,
-3. Release intermediate non-LTM `major.minor.0` versions that are not expected to receive patch/bugfix releases,
-4. Roll patches/bugfixes targeting non-LTM versions into the next `major.minor.0` release, and
-5. Support upgrades from both the immediately preceding LTM and non-LTM versions.
+3. Support upgrades from both the immediately preceding LTM and non-LTM versions
 
 This strategy implies that no more than one or two LTM releases will be
-actively maintained at any given time, with a one year overlap.
+actively maintained at any given time, with a one-year overlap.
 
-The motivation for this is to streamline the work of maintaining multiple
-versions of Accumulo while not inhibiting development on newer versions, to
-provide greater confidence for risk-averse users to upgrade to versions that
-are expected to be stable and receive updates (with a one year window to do
-so), and help reduce the amount of work done by limiting upgrade paths.
+Non-LTM versions:
+
+1. Release intermediate non-LTM `major.minor.0` versions that are not expected to receive patch/bugfix releases,
+2. Roll patches/bugfixes targeting non-LTM versions into the next `major.minor.0` release
+
+Goals of the LTM strategy:
+- Streamline maintaining multiple versions of Accumulo
+- Encourage development on newer versions
+- Provide greater confidence for users to upgrade and receive updates (within one year)
+- Help reduce the amount of work done by limiting upgrade paths
 
 Note: the above strategy is a declaration of **intent** only. We use the term
 "Long Term Maintenance" rather than the more familiar "Long Term Support" or
-"Long Term Stable" terms to avoid possible confusion that may arise over
-implication of warrantees from the use of the words "support" or "stable". See
-the project LICENSE for a full disclaimer of warranties. If you have questions,
-about this, please [contact] us.
+"Long Term Stable" terms to avoid confusion over the implication of warranties
+from the use of the words "support" or "stable". See the project LICENSE for a full
+disclaimer of warranties. If you have questions, about this, please [contact] us.
 
 ## SemVer 2.0.0
 {: semver }

--- a/contributor/versioning.md
+++ b/contributor/versioning.md
@@ -15,7 +15,7 @@ This strategy entails an intent to:
 3. Support upgrades from both the immediately preceding LTM and non-LTM versions
 
 This strategy implies that no more than one or two LTM releases will be
-actively maintained at any given time, with a one-year overlap.
+actively maintained at any given time, with one year of overlap.
 
 Non-LTM versions:
 

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@ skiph1fortitle: true
       </div>
       <div class="col-md-6">
         <h4>Stable</h4>
-        <p>Accumulo has a stable <a href="/latest/apidocs">client API</a> that follows <a href="https://semver.org">semantic versioning</a>. Each Accumulo release goes through <a href="{{ site.docs_baseurl }}/getting-started/features#testing">extensive testing</a>.</p>
+        <p>Accumulo has a stable <a href="/latest/apidocs">client API</a> that follows <a href="{{ site.baseurl }}/contributor/versioning">LTM releases and semantic versioning</a>. Each Accumulo release goes through <a href="{{ site.docs_baseurl }}/getting-started/features#testing">extensive testing</a>.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
* Simplify some of the wording in the LTM description
* Split up the LTM and non-LTM intents, since some users may
only care about the LTM releases
* Minor spelling corrections
* Clarify the motivation paragraph by making bullets of goals