### PR TITLE
Update combiner.md to use correct 'setiter' output.

### DIFF
--- a/1.10/examples/combiner.md
+++ b/1.10/examples/combiner.md
@@ -29,11 +29,13 @@ tar distribution.
     Combiner that keeps track of min, max, sum, and count
     ----------> set StatsCombiner parameter all, set to true to apply Combiner to every column, otherwise leave blank. if true, columns option will be ignored.:
     ----------> set StatsCombiner parameter columns, <col fam>[:<col qual>]{,<col fam>[:<col qual>]} escape non aplhanum chars using %<hex>.: stat
+    ----------> set StatsCombiner parameter reduceOnFullCompactionOnly, If true, only reduce on full major compactions.  Defaults to false. :
     ----------> set StatsCombiner parameter radix, radix/base of the numbers: 10
     username@instance runners> setiter -t runners -p 11 -scan -minc -majc -n hexStats -class org.apache.accumulo.examples.simple.combiner.StatsCombiner
     Combiner that keeps track of min, max, sum, and count
     ----------> set StatsCombiner parameter all, set to true to apply Combiner to every column, otherwise leave blank. if true, columns option will be ignored.:
     ----------> set StatsCombiner parameter columns, <col fam>[:<col qual>]{,<col fam>[:<col qual>]} escape non aplhanum chars using %<hex>.: hstat
+    ----------> set StatsCombiner parameter reduceOnFullCompactionOnly, If true, only reduce on full major compactions.  Defaults to false. :
     ----------> set StatsCombiner parameter radix, radix/base of the numbers: 16
     username@instance runners> insert 123456 name first Joe
     username@instance runners> insert 123456 stat marathon 240


### PR DESCRIPTION
The combiner.md file was missing a line of output for the <code>setiter</code> command. This update adds the missing output line in order to properly display expected output in the example.