### PR TITLE
initial draft of Apache 2021-01 report

### DIFF
--- a/reports/202101_apache_report.md
+++ b/reports/202101_apache_report.md
@@ -9,9 +9,11 @@ design and is built on top of Apache Hadoop, Zookeeper, and Thrift.
 
 ## Issues:
 
-No change since last report, Oct 2020.  Still waiting for the owner of 
-http://www.accumulodata.com to work with Amazon to reactive the account used for 
-hosting, so it can be pointed to https://accumulo.apache.org or shutdown. Initial emails are at [1].
+The owner of http://www.accumulodata.com no longer has access to the email used to register the 
+domain, and the registrar will not accept communications from alternate accounts.  Currently, the 
+domain is set to expire on 2021-06-28, and without access by the owner, should automatically expire.
+The Accumulo PMC is currently trying to determine if other actions are required. Initial emails are 
+at [1] and follow-up discussions at [4].
 
 ## Membership Data:
 
@@ -50,3 +52,4 @@ Community changes, past quarter:
 [1]:https://lists.apache.org/thread.html/514d3cf9162e72f4aa13be1db5d6685999fc83755695308a529de4d6@%3Cprivate.accumulo.apache.org%3E
 [2]:https://lists.apache.org/thread.html/r947a56c98d0a8e009fa93df3b19e93761bfea8b236f30fb0c21b1992%40%3Cuser.accumulo.apache.org%3E
 [3]:https://lists.apache.org/thread.html/r38b0920499c9c88de282ca783debb9fbb8dc8ed88f5fc0ad9981bf97%40%3Cuser.accumulo.apache.org%3E
+[4]:https://lists.apache.org/thread.html/rcc8c07db43222e08b9992fd739b8f24d18569ba9af3decfdb52c4a3e%40%3Cprivate.accumulo.apache.org%3E

--- a/reports/202101_apache_report.md
+++ b/reports/202101_apache_report.md
@@ -1,56 +1,62 @@
-[DRAFT][REPORT] Apache Accumulo - January 2021
+[REPORT] Apache Accumulo - January 2021
 
 ## Description:
-
-The Apache Accumulo sorted, distributed key/value store is a robust, scalable,
-high performance data storage system that features cell-based access control
-and customizable server-side processing. It is based on Google's BigTable
-design and is built on top of Apache Hadoop, Zookeeper, and Thrift.
+The mission of Apache Accumulo is the creation and maintenance of software
+related to a robust, scalable, distributed key/value store with cell-based
+access control and customizable server-side processing. It is based on
+Google's BigTable design and is built on top of Apache Hadoop, Zookeeper, and
+Thrift.
 
 ## Issues:
-
-The owner of http://www.accumulodata.com no longer has access to the email used to register the 
-domain, and the registrar will not accept communications from alternate accounts.  Currently, the 
-domain is set to expire on 2021-06-28, and without access by the owner, should automatically expire.
-The Accumulo PMC is currently trying to determine if other actions are required. Initial emails are 
-at [1] and follow-up discussions at [4].  Advice received Brand Management VP suggested that 
-allowing the domain to expire in 6 months is a viable option and allows volunteer efforts to be put 
-towards better uses.  
+Trademark issue with http://www.accumulodata.com: The owner of no longer has
+access to the email used to register the domain, and the registrar will not
+accept communications from alternate accounts.  Currently, the domain is set
+to expire on 2021-06-28, and without access by the owner, should automatically
+expire. The Accumulo PMC is currently trying to determine if other actions are
+required. Initial emails are at [1] and follow-up discussions at [4].  Advice
+received Brand Management VP suggested that allowing the domain to expire in 6
+months is a viable option and allows volunteer efforts to be put towards
+better uses.
 
 ## Membership Data:
-
 Apache Accumulo was founded 2012-03-20 (9 years ago)
 There are currently 38 committers and 38 PMC members in this project.
 The Committer-to-PMC ratio is 1:1.
 
 Community changes, past quarter:
+- Ed Coleman approved on 2020-11-18 as PMC Chair and Vice President of Apache
+  Accumulo.
 - Jeffrey Manno was added to the PMC on 2020-11-01
 - Jeffrey Manno was added as committer on 2020-11-02
 
-## Project Release Activity
 
+## Project Release Activity:
 - accumulo-1.10.1 was released on 2020-12-22 [2]
 - accumulo-2.0.1 was released on 2020-12-24. [3]
 
 ## Project Activity:
-
-- [CVE-2020-17533](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-17533) was reported on 
-  2020-12-09 and resolved within 14 days.  The CVE concerned allowed authenticated users to perform 
-  certain administrative operations without having the appropriate permissions.
-- Project activity on the next release remains active with significant improvements to the current 
-  baseline. The remaining issues are being actively worked.
-- There is community interest in improving support for cloud computing platforms (AWS, Azure) and 
-  alternate files systems.  
+- CVE-2020-17533 [5] was reported on 2020-12-09 and resolved within 14 days.
+  The CVE concerned allowed authenticated users to perform certain
+  administrative operations without having the appropriate permissions.
+- Project activity on the next release remains active with significant
+  improvements to the current baseline. The remaining issues are being
+  actively worked.
+- There is community interest in improving support for cloud computing
+  platforms (AWS, Azure) and alternate files systems.
 
 ## Community Health:
-
-- Mailing list participation and github issues are consistent.
-- 3 new contributors:
+- Mailing list participation and GitHub issues are consistent.
+- The large JIRA activity increase reflects migration or closing old JIRA
+  issues in favor of using GitHub for issue tracking.
+- 3 new contributors, each from different organizations showing continued
+  interest from a diverse community:
   - Szabolcs Bukros [Cloudera](https://www.cloudera.com/)
   - Seth Falco [Elypia](https://elypia.org/en-US/)
   - Dominic Garguilo [Arctic Slope Regional Corp](https://www.asrc.com/)
 
+## Links
 [1]:https://lists.apache.org/thread.html/514d3cf9162e72f4aa13be1db5d6685999fc83755695308a529de4d6@%3Cprivate.accumulo.apache.org%3E
 [2]:https://lists.apache.org/thread.html/r947a56c98d0a8e009fa93df3b19e93761bfea8b236f30fb0c21b1992%40%3Cuser.accumulo.apache.org%3E
 [3]:https://lists.apache.org/thread.html/r38b0920499c9c88de282ca783debb9fbb8dc8ed88f5fc0ad9981bf97%40%3Cuser.accumulo.apache.org%3E
 [4]:https://lists.apache.org/thread.html/rcc8c07db43222e08b9992fd739b8f24d18569ba9af3decfdb52c4a3e%40%3Cprivate.accumulo.apache.org%3E
+[5]:https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-17533

--- a/reports/202101_apache_report.md
+++ b/reports/202101_apache_report.md
@@ -13,7 +13,9 @@ The owner of http://www.accumulodata.com no longer has access to the email used 
 domain, and the registrar will not accept communications from alternate accounts.  Currently, the 
 domain is set to expire on 2021-06-28, and without access by the owner, should automatically expire.
 The Accumulo PMC is currently trying to determine if other actions are required. Initial emails are 
-at [1] and follow-up discussions at [4].
+at [1] and follow-up discussions at [4].  Advice received Brand Management VP suggested that 
+allowing the domain to expire in 6 months is a viable option and allows volunteer efforts to be put 
+towards better uses.  
 
 ## Membership Data:
 
@@ -32,14 +34,13 @@ Community changes, past quarter:
 
 ## Project Activity:
 
-- [CVE-2020-17533](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-17533), authenticated 
-  users could perform certain administrative operations without having the appropriate permissions, 
-  was reported on 2020-12-09 and resolved with the accumulo-2.0.1 (2020-12-24) and accumulo-1.10.1 
-  (2020-12-22) releases.
-- GitHub activity summary over the past quarter (as of 2021-01-07) 
-  - 48 GitHub issues created / 44 issues closed.
-  - 120 GitHib PRs opened / 97 PRs closed.
-  - 145 commits from 18 committers.
+- [CVE-2020-17533](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-17533) was reported on 
+  2020-12-09 and resolved within 14 days.  The CVE concerned allowed authenticated users to perform 
+  certain administrative operations without having the appropriate permissions.
+- Project activity on the next release remains active with significant improvements to the current 
+  baseline. The remaining issues are being actively worked.
+- There is community interest in improving support for cloud computing platforms (AWS, Azure) and 
+  alternate files systems.  
 
 ## Community Health:
 

--- a/reports/202101_apache_report.md
+++ b/reports/202101_apache_report.md
@@ -1,0 +1,52 @@
+[DRAFT][REPORT] Apache Accumulo - January 2021
+
+## Description:
+
+The Apache Accumulo sorted, distributed key/value store is a robust, scalable,
+high performance data storage system that features cell-based access control
+and customizable server-side processing. It is based on Google's BigTable
+design and is built on top of Apache Hadoop, Zookeeper, and Thrift.
+
+## Issues:
+
+No change since last report, Oct 2020.  Still waiting for the owner of 
+http://www.accumulodata.com to work with Amazon to reactive the account used for 
+hosting, so it can be pointed to https://accumulo.apache.org or shutdown. Initial emails are at [1].
+
+## Membership Data:
+
+Apache Accumulo was founded 2012-03-20 (9 years ago)
+There are currently 38 committers and 38 PMC members in this project.
+The Committer-to-PMC ratio is 1:1.
+
+Community changes, past quarter:
+- Jeffrey Manno was added to the PMC on 2020-11-01
+- Jeffrey Manno was added as committer on 2020-11-02
+
+## Project Release Activity
+
+- accumulo-1.10.1 was released on 2020-12-22 [2]
+- accumulo-2.0.1 was released on 2020-12-24. [3]
+
+## Project Activity:
+
+- [CVE-2020-17533](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-17533), authenticated 
+  users could perform certain administrative operations without having the appropriate permissions, 
+  was reported on 2020-12-09 and resolved with the accumulo-2.0.1 (2020-12-24) and accumulo-1.10.1 
+  (2020-12-22) releases.
+- GitHub activity summary over the past quarter (as of 2021-01-07) 
+  - 48 GitHub issues created / 44 issues closed.
+  - 120 GitHib PRs opened / 97 PRs closed.
+  - 145 commits from 18 committers.
+
+## Community Health:
+
+- Mailing list participation and github issues are consistent.
+- 3 new contributors:
+  - Szabolcs Bukros [Cloudera](https://www.cloudera.com/)
+  - Seth Falco [Elypia](https://elypia.org/en-US/)
+  - Dominic Garguilo [Arctic Slope Regional Corp](https://www.asrc.com/)
+
+[1]:https://lists.apache.org/thread.html/514d3cf9162e72f4aa13be1db5d6685999fc83755695308a529de4d6@%3Cprivate.accumulo.apache.org%3E
+[2]:https://lists.apache.org/thread.html/r947a56c98d0a8e009fa93df3b19e93761bfea8b236f30fb0c21b1992%40%3Cuser.accumulo.apache.org%3E
+[3]:https://lists.apache.org/thread.html/r38b0920499c9c88de282ca783debb9fbb8dc8ed88f5fc0ad9981bf97%40%3Cuser.accumulo.apache.org%3E


### PR DESCRIPTION
*** DO NOT MERGE ***  Draft Apache Accumulo January 2021 Report

The Apache Accumulo PMC decided to draft its quarterly board reports on the dev list. Here is a draft of our report which is due Wednesday, Jan 14.  I am hoping that as a PR, collaboration may be easier than emails, however I'm not sure this project is the most appropriate, and hoping for feedback on this as an approach in general and consensus as to the best vehicle going forward.

I will also post to the dev list.

