### PR TITLE
Fix Accumulo Tour page 1 missing exception

### DIFF
--- a/tour/getting-started.md
+++ b/tour/getting-started.md
@@ -19,7 +19,7 @@ great here on the tour.  Files and logs used by [MiniAccumuloCluster] can be see
 
 3. Modify the _exercise_ method to print a hello message. You will put your code in this method for each lesson.
 ```java
-  static void exercise(AccumuloClient client) {
+  static void exercise(AccumuloClient client) throws Exception {
     // Write your code here
     System.out.println("Hello world");
   }


### PR DESCRIPTION
When I was completing the Accumulo Tour, I noticed that on the first page, there was a missing part of code in section 3.

Section 3 of the page tells the user to modify the `exercise` method (which is shown to them). When the user then reads `Main.java`, the two code segments do not match. Though it is a small difference, I figured this may cause confusion to some people.

On all other pages of the tour, the exercise method includes "throws Exception".

This PR fixes the issue outlined above.