### PR TITLE
Add JShell version of the Accumulo Tour to website

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ ruby '>=2.5.1'
 source 'https://rubygems.org'
 gem 'jekyll', '>= 4.2.0'
 gem 'jekyll-redirect-from', '>= 0.16.0'
+
+gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,7 @@ GEM
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     unicode-display_width (1.7.0)
+    webrick (1.7.0)
 
 PLATFORMS
   ruby
@@ -65,6 +66,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (>= 4.2.0)
   jekyll-redirect-from (>= 0.16.0)
+  webrick (~> 1.7)
 
 RUBY VERSION
    ruby 2.7.1p83

--- a/_config.yml
+++ b/_config.yml
@@ -46,6 +46,13 @@ defaults:
       permalink: "/tour/:basename/"
   -
     scope:
+      path: "tour-jshell"
+      type: "pages"
+    values:
+      layout: "tour-jshell"
+      permalink: "/tour-jshell/:basename/"
+  -
+    scope:
       path: "_posts/blog"
       type: "posts"
     values:

--- a/_data/tour-jshell.yml
+++ b/_data/tour-jshell.yml
@@ -1,0 +1,14 @@
+docs:
+ - getting-started2
+ - client2
+ - basic-read-write2
+ - data-model2
+ - data-model-code2
+ - authorizations2
+ - authorizations-code2
+ - ranges-splits2
+ - batch-scanner2
+ - batch-scanner-code2
+ - conditional-writer2
+ - conditional-writer-code2
+ - using-iterators2

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -13,12 +13,12 @@
     <div class="collapse navbar-collapse" id="navbar-items">
       <ul class="nav navbar-nav">
         <li class="nav-link"><a href="{{ site.baseurl }}/downloads">Download</a></li>
-        <li class="nav-link"><a href="{{ site.baseurl }}/tour">Tour</a></li>
+        <li class="nav-link"><a href="{{ site.baseurl }}/accumulo-tour">Tour</a></li>
         <li class="dropdown">
           <a class="dropdown-toggle" data-toggle="dropdown" href="#">Releases<span class="caret"></span></a>
           <ul class="dropdown-menu">
             <li><a href="{{ site.baseurl }}/release/accumulo-2.0.1/">2.0.1 (Latest)</a></li>
-            <li><a href="{{ site.baseurl }}/release/accumulo-1.10.1/">1.10.1</a></li>
+            <li><a href="{{ site.baseurl }}/release/accumulo-1.10.2/">1.10.2</a></li>
             <li><a href="{{ site.baseurl }}/release/">Archive</a></li>
           </ul>
         </li>

--- a/_layouts/tour-jshell.html
+++ b/_layouts/tour-jshell.html
@@ -1,0 +1,55 @@
+---
+layout: default
+---
+{% assign tour_pages = site.data.tour-jshell.docs %}
+{% for p in tour_pages %}
+  {% assign doc_url = p | prepend: '/tour-jshell/' | append: '/' %}
+  {% if doc_url == page.url %}
+    {% assign tour_num = forloop.index %}
+    {% if forloop.first %}
+      {% assign previous = -1 %}
+    {% else %}
+      {% assign previous = forloop.index0 | minus: 1 %}
+      {% assign previous_page = tour_pages[previous] | prepend:"/tour-jshell/" | append:"/" %}
+    {% endif %}
+    {% if forloop.last %}
+      {% assign next = 0 %}
+    {% else %}
+      {% assign next = forloop.index0 | plus: 1 %}
+      {% assign next_page = tour_pages[next] | prepend:"/tour-jshell/" | append:"/" %}
+    {% endif %}
+  {% endif %}
+{% endfor %}
+
+<div id="tour-header">
+    <h2><a href="/tour-jshell/">Accumulo Tour</a>: {{ page.title }}</h2>
+    <p class="text-muted">Tour page {{ tour_num }} of {{ tour_pages.size }}</p>
+</div>
+<div id="tour-content">
+    {{ content }}
+</div>
+
+<script>
+    document.body.onkeyup = function(e){
+        {% if previous >= 0 %}
+        if (e.keyCode == '37') { window.location = '{{previous_page}}'; }
+        {% endif %}
+
+        {% if next > 0 %}
+        if (e.keyCode == '39') { window.location = '{{next_page}}'; }
+        {% endif %}
+    };
+</script>
+
+<div class="text-center">
+    <h2>
+        {% if previous >= 0 %}
+        <a href="{{ previous_page }}">&lt;</a>
+        {% endif %}
+
+        {{ tour_num }} / {{ tour_pages.size }}
+        {% if next > 0 %}
+        <a href="{{ next_page }}">&gt;</a>
+        {% endif %}
+    </h2>
+</div>

--- a/pages/tour.md
+++ b/pages/tour.md
@@ -1,0 +1,37 @@
+---
+title: Accumulo Tour
+layout: page
+permalink: /accumulo-tour/
+skiph1fortitle: true
+---
+
+{% assign tour_pages = site.data.tour.docs %}
+{% assign first_url = tour_pages[0] | prepend: '/tour/' | append: '/' %}
+{% assign first_page = site.pages | where:'url',first_url | first %}
+
+{% assign jshell_pages = site.data.tour-jshell.docs %}
+{% assign first_jshell_url = tour_pages[0] | prepend: '/tour-jshell/' | append: '/' %}
+{% assign first_jshell_page = site.pages | where:'url',first_jshell_url | first %}
+
+Welcome to the Accumulo tour! The tour offers a hands-on introduction to the [Accumulo Java API](/api),
+broken down into independent steps and exercises. The exercises give you a chance to apply what you have
+learned by writing code on your own. The answers to an exercise are typically provided in the next step.
+
+There are two options for using the tour. The first utilizes Accumulo's MiniAccumuloCluster and 
+standard Java class development to progress through the tour. The second uses the newer Accumulo
+JShell feature, introduced in version 2.1.0, to complete the tour.
+
+The MiniAccumuloCluster version can be found [here][mac-tour]. If using Accumulo 2.0.x, this is the 
+version that must be followed.
+
+The JShell version begins [here][jshell-tour]. This version is available for version 2.1.x or greater. 
+
+
+* [**MiniAccumuloCluster Tour**][mac-tour]
+* [**JShell Tour**][jshell-tour]
+
+
+[mlist]: /contact-us/#mailing-lists
+[issue]: https://github.com/apache/accumulo-website/issues
+[mac-tour]: /tour/
+[jshell-tour]: /tour-jshell/

--- a/tour-jshell/authorizations-code2.md
+++ b/tour-jshell/authorizations-code2.md
@@ -1,0 +1,153 @@
+---
+title: Authorizations Code
+---
+
+Below is the solution for the previous Authorization exercise. 
+
+For this example, it is best to start with a clean slate. So, if the "GothamPD" table currently 
+exists, let's delete and begin fresh.
+
+```commandline
+client.tableOperations().delete("GothamPD");
+client.securityOperations().dropLocalUser("commissioner"); 
+```
+
+Create a table called "GothamPD".
+```commandline
+jshell> client.tableOperations().create("GothamPD");
+```
+Create a "secretId" authorization & visibility
+```commandline
+jshell> String secretId = "secretId";
+secretId ==> "secretId"
+jshell> Authorizations auths = new Authorizations(secretId);
+auths ==> secretId
+jshell> ColumnVisibility colVis = new ColumnVisibility(secretId);
+colVis ==> [secretId]
+```
+
+Create a user with the "secretId" authorization and grant the commissioner read permissions on our table
+```commandline
+jshell> client.securityOperations().createLocalUser("commissioner", new PasswordToken("gordonrocks"));
+jshell> client.securityOperations().changeUserAuthorizations("commissioner", auths);
+jshell> client.securityOperations().grantTablePermission("commissioner", "GothamPD", TablePermission.READ);
+```
+
+Create three Mutation objects, securing the proper columns.
+```commandline
+jshell> Mutation mutation1 = new Mutation("id0001");
+mutation1 ==> org.apache.accumulo.core.data.Mutation@1
+jshell> mutation1.put("hero", "alias", "Batman");
+jshell> mutation1.put("hero", "name", colVis, "Bruce Wayne");
+jshell> mutation1.put("hero", "wearsCape?", "true");
+
+jshell> Mutation mutation2 = new Mutation("id0002");
+mutation2 ==> org.apache.accumulo.core.data.Mutation@1
+jshell> mutation2.put("hero", "alias", "Robin");
+jshell> mutation2.put("hero", "name", colVis, "Dick Grayson");
+jshell> mutation2.put("hero", "wearsCape?", "true");
+
+jshell> Mutation mutation3 = new Mutation("id0003");
+mutation3 ==> org.apache.accumulo.core.data.Mutation@1
+jshell> mutation3.put("villain", "alias", "Joker");
+jshell> mutation3.put("villain", "name", "Unknown");
+jshell> mutation3.put("villain", "wearsCape?", "false");
+```
+
+Create a BatchWriter to the GothamPD table and add your mutations to it.
+Once the BatchWriter is closed the data will be available to scans.
+
+```commandline
+jshell> try (BatchWriter writer = client.createBatchWriter("GothamPD")) {
+    ...>   writer.addMutation(mutation1);
+    ...>   writer.addMutation(mutation2);
+    ...>   writer.addMutation(mutation3);
+    ...> }
+```
+
+Now let's scan.
+
+```commandline
+jshell> try (ScannerBase scan = client.createScanner("GothamPD", Authorizations.EMPTY)) {
+   ...>   System.out.println("Gotham Police Department Persons of Interest:");
+   ...>     for (Map.Entry<Key, Value> entry : scan) {
+   ...>     System.out.printf("Key : %-50s  Value : %s\n", entry.getKey(), entry.getValue());
+   ...>   }
+   ...> }
+Gotham Police Department Persons of Interest:
+Key : id0001 hero:alias [] 1654783465209 false            Value : Batman
+Key : id0001 hero:wearsCape? [] 1654783465209 false       Value : true
+Key : id0002 hero:alias [] 1654783465209 false            Value : Robin
+Key : id0002 hero:wearsCape? [] 1654783465209 false       Value : true
+Key : id0003 villain:alias [] 1654783465209 false         Value : Joker
+Key : id0003 villain:name [] 1654783465209 false          Value : Unknown
+Key : id0003 villain:wearsCape? [] 1654783465209 false    Value : false
+```
+
+Note that the default root user can no longer see the name for the two hero's since they are protected
+with the `secretId` authorization.
+
+Let's add the `auths` authorization to the default root user and scan again.
+
+```commandline
+ jshell> try (ScannerBase scan = client.createScanner("GothamPD", auths)) {
+   ...>    System.out.println("Gotham Police Department Persons of Interest:");
+   ...>      for (Map.Entry<Key, Value> entry : scan)
+   ...>        System.out.printf("Key : %-50s  Value : %s\n", entry.getKey(), entry.getValue());
+   ...>      }
+Gotham Police Department Persons of Interest:
+|  Exception java.lang.RuntimeException: org.apache.accumulo.core.client.AccumuloSecurityException: Error BAD_AUTHORIZATIONS for user root on table GothamPD(ID:2) - The user does not have the specified authorizations assigned
+|        at ScannerIterator.getNextBatch (ScannerIterator.java:180)
+|        at ScannerIterator.hasNext (ScannerIterator.java:105)
+|        at (#54:3)
+|  Caused by: org.apache.accumulo.core.client.AccumuloSecurityException: Error BAD_AUTHORIZATIONS for user root on table GothamPD(ID:2) - The user does not have the specified authorizations assigned
+|        at ThriftScanner.scan (ThriftScanner.java:574)
+|        at ThriftScanner.scan (ThriftScanner.java:326)
+|        at ScannerIterator.readBatch (ScannerIterator.java:151)
+|        at ScannerIterator.getNextBatch (ScannerIterator.java:169)
+|        ...
+|  Caused by: org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException
+|        at TabletScanClientService$startScan_result$startScan_resultStandardScheme.read (TabletScanClientService.java:4233)
+|        at TabletScanClientService$startScan_result$startScan_resultStandardScheme.read (TabletScanClientService.java:4210)
+|        at TabletScanClientService$startScan_result.read (TabletScanClientService.java:4125)
+|        at TServiceClient.receiveBase (TServiceClient.java:88)
+|        at TabletScanClientService$Client.recv_startScan (TabletScanClientService.java:117)
+|        at TabletScanClientService$Client.startScan (TabletScanClientService.java:89)
+|        at ThriftScanner.scan (ThriftScanner.java:483)
+|        ...
+ 
+```
+
+This results in an error since the root user doesn't have the authorizations we tried to pass to the Scanner
+
+Now, create a second client for the commissioner user and output all the rows visible to them.
+Make sure to pass the proper authorizations.
+
+```commandline
+jshell> try (AccumuloClient commishClient = Accumulo.newClient().from(client.properties()).as("commissioner", "gordonrocks").build()) {
+   ...>   try (ScannerBase scan = commishClient.createScanner("GothamPD", auths)) {
+   ...>     System.out.println("Gotham Police Department Persons of Interest:");
+   ...>     for (Map.Entry<Key, Value> entry : scan) {
+   ...>       System.out.printf("Key : %-50s  Value : %s\n", entry.getKey(), entry.getValue());
+   ...>     }
+   ...>   } 
+   ...> }
+```
+
+The solution above will print (timestamp will differ):
+
+```commandline
+Gotham Police Department Persons of Interest:
+Key : id0001 hero:alias [] 1654106385737 false            Value : Batman
+Key : id0001 hero:name [secretId] 1654106385737 false     Value : Bruce Wayne
+Key : id0001 hero:wearsCape? [] 1654106385737 false       Value : true
+Key : id0002 hero:alias [] 1654106385737 false            Value : Robin
+Key : id0002 hero:name [secretId] 1654106385737 false     Value : Dick Grayson
+Key : id0002 hero:wearsCape? [] 1654106385737 false       Value : true
+Key : id0003 villain:alias [] 1654106385737 false         Value : Joker
+Key : id0003 villain:name [] 1654106385737 false          Value : Unknown
+Key : id0003 villain:wearsCape? [] 1654106385737 false    Value : false
+```
+
+
+

--- a/tour-jshell/authorizations2.md
+++ b/tour-jshell/authorizations2.md
@@ -1,0 +1,61 @@
+---
+title: Authorizations
+---
+
+[Authorizations] are a set of `String`'s that enable a user to read protected data. Users are granted 
+authorizations and choose which ones to use when scanning a table. The chosen authorizations are evaluated 
+against the [ColumnVisibility] of each Accumulo key in the scan. If the boolean expression of the 
+ColumnVisibility evaluates to true, the data will be visible to the user.
+
+For example:
+* Bob has authorizations `product, sales`
+* Tina has authorizations `sales, employee`
+* The key `row1:family1:qualifier1` has visibility `sales && employee`
+* When Bob scans with all of his authorizations, he will **not** see `row1:family1:qualifier1`
+* When Tina scans with all of her authorizations, she will see `row1:family1:qualifier1`
+
+For the next exercise we want to secure our secret identities of the heroes so that only users with 
+the proper authorizations can read their names.
+
+Create a "secretId" authorization & visibility.
+
+```commandline
+jshell> String secretId = "secretId";
+secretId ==> "secretId"
+
+jshell> Authorizations auths = new Authorizations(secretId);
+auths ==> secretId
+
+jshell> ColumnVisibility colVis = new ColumnVisibility(secretId);
+colVis ==> [secretId]
+```
+
+Create a user with the "secretId" authorization and grant read permissions on our table.
+
+```commandline
+jshell> client.securityOperations().createLocalUser("commissioner", new PasswordToken("gordonrocks"));
+jshell> client.securityOperations().changeUserAuthorizations("commissioner", auths);
+jshell> client.securityOperations().grantTablePermission("commissioner", "GothamPD", TablePermission.READ);
+```
+
+The [Mutation] API allows you to set the `secretId` visibility on a column. Find the proper method for 
+setting a column visibility in the Mutation API and modify the code so the `colVis` variable created 
+above secures the "name" columns.
+
+What data do you see?
+
+* You should see all the data except the secret identities of Batman and Robin. This is because the 
+`Scanner` was created from the root user which doesn't have the `secretId` authorization.
+* Replace the `Authorizations.EMPTY` in the Scanner with the `auths` variable created above and run 
+it again. This should result in an error since the root user doesn't have the authorizations we 
+tried to pass to the Scanner.
+
+Next, create a client for the "commissioner". Using the commissioner client, create a Scanner with the 
+authorizations needed to view the secret identities. You should see all the rows in the GothamPD table 
+printed, including the secured key/value pairs:
+
+
+[Authorizations]: {% jurl org.apache.accumulo.core.security.Authorizations %}
+[ColumnVisibility]: {% jurl org.apache.accumulo.core.security.ColumnVisibility %}
+[Mutation]: {% jurl org.apache.accumulo.core.data.Mutation %}
+[Accumulo]: {% jurl org.apache.accumulo.core.client.Accumulo %}

--- a/tour-jshell/basic-read-write2.md
+++ b/tour-jshell/basic-read-write2.md
@@ -1,0 +1,80 @@
+---
+title: Writing and Reading
+---
+
+Accumulo is a big key/value store.  Writing data to Accumulo is flexible and fast.  Like any 
+database, Accumulo stores data in tables and rows.  Each row in an Accumulo table can hold many 
+key/value pairs. 
+
+Our next exercise shows how to write and read from a table.
+
+Let's create a table called "GothamPD".
+
+At the JShell prompt, enter the following:
+```commandline
+jshell> client.tableOperations().create("GothamPD");
+```
+
+Accumulo uses Mutation objects to hold all changes to a row in a table. Each row has a unique row
+ID. 
+
+```commandline
+jshell> Mutation mutation1 = new Mutation("id0001");
+mutation1 ==> org.apache.accumulo.core.data.Mutation@1
+```
+
+Create key/value pairs for Batman.  Put them in the "hero" family.
+```commandline
+jshell> mutation1.put("hero","alias", "Batman");
+jshell> mutation1.put("hero","name", "Bruce Wayne");
+jshell> mutation1.put("hero","wearsCape?", "true");
+```
+
+Create a BatchWriter to the GothamPD table and add your mutation to it. Try-with-resources will 
+close for us.
+
+```commandline
+jshell> try (BatchWriter writer = client.createBatchWriter("GothamPD")) {
+  ...>    writer.addMutation(mutation1);
+  ...>  }
+```
+Read and print all rows of the "GothamPD" table.
+
+Note that within the JShell environment, references to Scanner are ambiguous since it matches both 
+interface ```org.apache.accumulo.core.client.Scanner``` and class ```java.util.Scanner```. This can 
+be resolved by either using the fully qualified name for the Scanner, or more easily, by using the 
+base class, ```ScannerBase```, in place of ```Scanner``` (this should generally only be required when 
+within the JShell environment).
+
+```commandline
+jshell> try (ScannerBase scan = client.createScanner("GothamPD", Authorizations.EMPTY)) {
+   ...>   System.out.println("Gotham Police Department Persons of Interest:");
+   ...>   for(Map.Entry<Key, Value> entry : scan) {
+   ...>     System.out.printf("Key : %-50s  Value : %s\n", entry.getKey(), entry.getValue());
+   ...>   }
+   ...> }
+Gotham Police Department Persons of Interest:
+Key : id0001 hero:alias [] 1654274195071 false            Value : Batman
+Key : id0001 hero:name [] 1654274195071 false             Value : Bruce Wayne
+Key : id0001 hero:wearsCape? [] 1654274195071 false       Value : true
+```
+
+Be aware the timestamps will differ for you.
+
+Good job! That is all it takes to write and read from Accumulo.
+
+Notice a lot of other information was printed from the Keys we created. Accumulo is flexible 
+because hidden within its [Key] is a rich data model that can be broken up into different parts. We 
+will cover the [Data Model][dmodel] in the next lesson.
+
+### But wait... I thought Accumulo was all about Security?
+
+Spoiler Alert: It is!  Did you notice the `Authorizations.EMPTY` we passed in when creating a
+[Scanner]?  The data we created in this first lesson was not secured with Authorizations so the 
+Scanner didn't require any Authorizations to read it.  More to come later in the [Authorizations][auths] 
+lesson!
+
+[dmodel]: /tour-jshell/data-model2
+[auths]: /tour-jshell/authorizations2
+[Key]: {% jurl org.apache.accumulo.core.data.Key %}
+[Scanner]: {% jurl org.apache.accumulo.core.client.Scanner %}

--- a/tour-jshell/batch-scanner-code2.md
+++ b/tour-jshell/batch-scanner-code2.md
@@ -1,0 +1,57 @@
+---
+title: Batch Scanner Code
+---
+
+Below is a solution to the exercise.
+
+Create a table called "GothamBatch".
+
+```commandline
+jshell> client.tableOperations().create("GothamBatch");
+```
+
+Generate 10,000 rows of villain data
+
+```commandline
+jshell> try (BatchWriter writer = client.createBatchWriter("GothamBatch")) {
+   ...>   for (int i = 0; i < 10_000; i++) {
+   ...>     Mutation m = new Mutation(String.format("id%04d", i));
+   ...>     m.put("villain", "alias", "henchman" + i);
+   ...>     m.put("villain", "yearsOfService", "" + (new Random().nextInt(50)));
+   ...>     m.put("villain", "wearsCape?", "false");
+   ...>    writer.addMutation(m);
+   ...>   }
+   ...> }
+```
+
+Create a BatchScanner with 5 query threads
+```commandline
+jshell> try (BatchScanner batchScanner = client.createBatchScanner("GothamBatch", Authorizations.EMPTY, 5)) {
+   ...> 
+   ...>   // Create a collection of 2 sample ranges and set it to the batchScanner
+   ...>   List<Range> ranges = new ArrayList<Range>();
+   ...> 
+   ...>   // Create a collection of 2 sample ranges and set it to the batchScanner
+   ...>   ranges.add(new Range("id1000", "id1999"));
+   ...>   ranges.add(new Range("id9000", "id9999"));
+   ...>   batchScanner.setRanges(ranges);
+   ...> 
+   ...>   // Fetch just the columns we want
+   ...>   batchScanner.fetchColumn(new Text("villain"), new Text("yearsOfService"));
+   ...> 
+   ...>   // Calculate average years of service
+   ...>   Long totalYears = 0L;
+   ...>   Long entriesRead = 0L;
+   ...>   for (Map.Entry<Key, Value> entry : batchScanner) {
+   ...>     totalYears += Long.valueOf(entry.getValue().toString());
+   ...>     entriesRead++;
+   ...>   }
+   ...>   System.out.println("The average years of service of " + entriesRead + " villains is " + totalYears / entriesRead);
+   ...> }
+```
+
+Running the solution above should print output similar to below:
+
+```
+The average years of service of 2000 villains is 24
+```

--- a/tour-jshell/batch-scanner2.md
+++ b/tour-jshell/batch-scanner2.md
@@ -1,0 +1,41 @@
+---
+title: Batch Scanner
+---
+
+Running on a single thread, a `Scanner` will retrieve a single `Range` of data and return `Key`s in 
+sorted order. A [BatchScanner] will retrieve multiple `Range`s of data using multiple threads.  A 
+`BatchScanner` can be more efficient but does not guarantee `Key`s will be returned in sorted order.
+
+For this exercise, we need to generate a bunch of data to test BatchScanner.  Execute the code below
+to create our data set.
+
+```commandline
+jshell> try (BatchWriter writer = client.createBatchWriter("GothamPD")) {
+   ...>   for (int i = 0; i < 10_000; i++) {
+   ...>     Mutation m = new Mutation(String.format("id%04d", i));
+   ...>     m.put("villain", "alias", "henchman" + i);
+   ...>     m.put("villain", "yearsOfService", "" + (new Random().nextInt(50)));
+   ...>     m.put("villain", "wearsCape?", "false");
+   ...>     writer.addMutation(m);
+   ...>   }
+   ...> }
+```
+
+We want to calculate the average years of service from a sample of 2000 villains. A BatchScanner would 
+be good for this task because we don't need the returned keys to be sorted. Follow these steps to 
+efficiently scan the table with 10,000 entries.
+
+1. After the above code, create a BatchScanner with five query threads.  Similar to a Scanner, use 
+the [createBatchScanner] method.
+
+2. Create an ArrayList of two sample `Range`s (`id1000` to `id1999` and `id9000` to `id9999`) and set 
+the ranges of the [BatchScanner] using `setRanges`.
+
+3. We can make the scan more efficient by only bringing back the columns we want.  Use [fetchColumn] 
+to get the `villain` family and `yearsOfService` qualifier.
+
+4. Finally, use the BatchScanner to calculate the average years of service of 2000 villains.
+
+[BatchScanner]: {% jurl org.apache.accumulo.core.client.BatchScanner %}
+[createBatchScanner]: {% jurl org.apache.accumulo.core.client.Connector#createBatchScanner-java.lang.String-org.apache.accumulo.core.security.Authorizations-int- %}
+[fetchColumn]: {% jurl org.apache.accumulo.core.client.ScannerBase#fetchColumn-org.apache.hadoop.io.Text-org.apache.hadoop.io.Text- %}

--- a/tour-jshell/client2.md
+++ b/tour-jshell/client2.md
@@ -1,0 +1,53 @@
+---
+title: Connecting to Accumulo
+---
+
+Connecting to a live instance of Accumulo is done through the [AccumuloClient] object.  This object 
+contains a live connection to Accumulo and will remain open until closed.  All client operations 
+can be accessed from this one object.
+
+The [Accumulo] entry point is used to create a client by calling ```Accumulo.newClient()```.  The 
+client can be created from properties by using one of the ```from()``` methods or using the 
+```to()``` and ```as()``` methods to specify the connection information directly. A later example 
+will illustrate how to create a new client.
+
+For the tour, you will use the ```client``` provided by the JShell to perform the required operations.
+The properties used to create the client can be viewed in the file contained in the `clientPropUrl`
+variable. 
+
+```commandline
+jshell> /vars
+|    URL clientPropUrl = file:<path_to_accumulo-client.properties file>
+```
+
+Let's start by using table operations to list the default tables and instance operations to get 
+the instance ID.
+
+```commandline
+jshell> client.tableOperations().list().forEach(System.out::println);
+accumulo.metadata
+accumulo.replication
+accumulo.root
+```
+
+Now let's retrieve the instance ID.
+
+```commandline
+jshell> System.out.println(client.instanceOperations().getInstanceID());
+8b9839f7-cdc6-44ca-b527-43db45acc79f
+```
+
+Different types of operations are accessed by their respective methods on the client:
+
+* client.tableOperations();
+* client.namespaceOperations();
+* client.securityOperations();
+* client.instanceOperations();
+* client.replicationOperations();
+
+
+The client is also used to create Scanners and perform batch operations.  These will be
+explored later.
+
+[AccumuloClient]: {% jurl org.apache.accumulo.core.client.AccumuloClient %}
+[Accumulo]: {% jurl org.apache.accumulo.core.client.Accumulo %}

--- a/tour-jshell/conditional-writer-code2.md
+++ b/tour-jshell/conditional-writer-code2.md
@@ -1,0 +1,36 @@
+---
+title: Conditional Writer Code
+---
+
+Below is a solution to the exercise.
+
+```commandline
+jshell> boolean setAddress(AccumuloClient client, String id, String expectedAddr, String newAddr) {
+   ...>   try (ConditionalWriter writer = client.createConditionalWriter("GothamPD", new ConditionalWriterConfig())) {
+   ...>     Condition condition = new Condition("location", "home");
+   ...>     if (expectedAddr != null) {
+   ...>       condition.setValue(expectedAddr);
+   ...>     }
+   ...>     ConditionalMutation mutation = new ConditionalMutation(id, condition);
+   ...>     mutation.put("location", "home", newAddr);
+   ...>     return writer.write(mutation).getStatus() == ConditionalWriter.Status.ACCEPTED;
+   ...>   } catch (Exception e) {
+   ...>     throw new RuntimeException();
+   ...>   }
+   ...> }
+```
+
+The following output shows running the example with a conditional writer.
+Threads retry when conditional mutations are rejected.  The final address has
+all three modifications.
+
+```commandline
+jshell> concurrent_writes()
+GothamPD table already exists...proceeding...
+Thread  52 attempting change '   1007 Mountain Dr, Gotham, New York  ' -> '1007 Mountain Dr, Gotham, New York'
+Thread  91 attempting change '   1007 Mountain Dr, Gotham, New York  ' -> '   1007 Mountain Dr, Gotham, NY  '
+Thread  90 attempting change '   1007 Mountain Dr, Gotham, New York  ' -> '   1007 Mountain Dr, Gotham, New York  '
+Thread  90 attempting change '1007 Mountain Dr, Gotham, New York' -> '1007 Mountain Dr, Gotham, New York'
+Thread  91 attempting change '1007 Mountain Dr, Gotham, New York' -> '1007 Mountain Dr, Gotham, NY'
+Final address : '1007 Mountain Dr, Gotham, NY'
+```

--- a/tour-jshell/conditional-writer2.md
+++ b/tour-jshell/conditional-writer2.md
@@ -1,0 +1,132 @@
+---
+title: Conditional Writer
+---
+
+Suppose the Gotham PD is storing home addresses for persons of interest in
+Accumulo.  We want to correctly handle the case of multiple users editing the
+same address at the same time. The following sequence of events shows an example
+of how this can go wrong.
+
+ 1. User 0 sets the key `id0001:location:home` to `1007 Mountain Drive, Gotham, New York`
+ 2. User 1 reads `id0001:location:home`
+ 3. User 2 reads `id0001:location:home`
+ 4. User 1 replaces `Drive` with `Dr`
+ 5. User 2 replaces `New York` with `NY`
+ 6. User 1 sets key `id0001:location:home` to `1007 Mountain Dr, Gotham, New York`
+ 7. User 2 sets key `id0001:location:home` to `1007 Mountain Drive, Gotham, NY`
+
+In this situation the changes made by User 1 are lost, ending up with `1007
+Mountain Drive, Gotham, NY` instead of `1007 Mountain Dr, Gotham, New York`.  To
+correctly handle this, Accumulo offers the [ConditionalWriter].  The
+ConditionalWriter atomically checks conditions on a row and only applies a
+mutation when all conditions are satisfied.
+
+## Exercise
+
+The following code simulates the concurrency in the situation above.  The code
+starts multiple threads, with each thread doing the following.
+
+ 1. Read key's value into memory using a scanner
+ 2. Modify the copy in memory.
+ 3. Write out the modified value from memory using a batch writer.
+ 4. If write was unsuccessful, then goto step 1.
+
+This process can result in threads overwriting each other's changes.  The problem is the batch writer 
+always makes the update, even when the value has changed since it was read.
+
+To simplify, we will create several small methods to illustrate the issue.
+
+```commandline
+jshell> String getAddress(AccumuloClient client, String id)  {
+    ...>   try (org.apache.accumulo.core.client.Scanner scan = new IsolatedScanner(client.createScanner("GothamPD", Authorizations.EMPTY))) {
+    ...>     scan.setRange(Range.exact(id, "location", "home"));
+    ...>     for (Map.Entry<Key, Value> entry : scan) {
+    ...>       return entry.getValue().toString();
+    ...>     }
+    ...>     return null;
+    ...>   } catch (TableNotFoundException e) {
+    ...>     throw new RuntimeException(e);
+    ...>   }
+    ...> }
+    |  created method getAddress(AccumuloClient,String)
+
+
+jshell> boolean setAddress(AccumuloClient client, String id, String expectedAddr, String newAddr) {
+   ...>   try (BatchWriter writer = client.createBatchWriter("GothamPD")) {
+   ...>     Mutation mutation = new Mutation(id);
+   ...>     mutation.put("location", "home", newAddr);
+   ...>     writer.addMutation(mutation);
+   ...>     return true;
+   ...>   } catch (Exception e) {
+   ...>     throw new RuntimeException(e);
+   ...>   }
+   ...> }
+|  created method setAddress(AccumuloClient,String,String,String)
+
+
+jshell> Future<Void> modifyAddress(AccumuloClient client, String id, Function<String,String> modifier) throws Exception {
+   ...>   return CompletableFuture.runAsync(() -> {
+   ...>     String currAddr, newAddr;
+   ...>     do {
+   ...>       currAddr = getAddress(client, id);
+   ...>       newAddr = modifier.apply(currAddr);
+   ...>       System.out.printf("Thread %3d attempting change %20s -> %-20s\n",
+   ...>       Thread.currentThread().getId(), "'"+currAddr+"'", "'"+newAddr+"'");
+   ...>     } while (!setAddress(client, id, currAddr, newAddr));
+   ...>   });
+   ...> }
+|  created method modifyAddress(AccumuloClient,String,Function<String,String>)
+
+        
+jshell> void concurrent_writes() throws Exception {
+   ...>   try {
+   ...>     client.tableOperations().create("GothamPD");
+   ...>   } catch (TableExistsException e) {
+   ...>     System.out.println("GothamPD table already exists...proceeding...");
+   ...>   }
+   ...>   String id = "id0001";
+   ...>   setAddress(client, id, null, "   1007 Mountain Drive, Gotham, New York  ");
+   ...>   Future<Void> future1 = modifyAddress(client, id, String::trim);
+   ...>   Future<Void> future2 = modifyAddress(client, id, addr -> addr.replace("Drive", "Dr"));
+   ...>   Future<Void> future3 = modifyAddress(client, id, addr -> addr.replace("New York", "NY"));
+   ...>   future1.get();
+   ...>   future2.get();
+   ...>   future3.get();
+   ...>   System.out.println("Final address : '" + getAddress(client, id) + "'");
+   ...> }
+|  created method concurrent_writes()
+
+```
+
+The following is one of a few possible outputs.  Notice that only the
+modification of `Drive` to `Dr` shows up in the final output.  The other
+modifications were lost.
+
+```commandline
+jshell> concurrent_writes()
+GothamPD table already exists...proceeding...
+Thread  52 attempting change '   1007 Mountain Drive, Gotham, New York  ' -> '   1007 Mountain Drive, Gotham, NY  '
+Thread  38 attempting change '   1007 Mountain Drive, Gotham, New York  ' -> '1007 Mountain Drive, Gotham, New York'
+Thread  53 attempting change '   1007 Mountain Drive, Gotham, New York  ' -> '   1007 Mountain Dr, Gotham, New York  '
+Final address : '   1007 Mountain Dr, Gotham, New York  '
+
+```
+
+To fix this example, make the following changes in `setAddress()` to use a
+ConditionalWriter.
+
+ * Call [createConditionalWriter] instead of creating a batch writer
+ * Create a [Condition] for the column 'location:home'.  If `expectedAddr` is not null, then call [setValue] passing `expectedAddr`.  If `expectedAddr` is null, then do nothing else with the condition. A condition with no value means that column is expected to be absent.
+ * Replace Mutation with a [ConditionalMutation] and pass the condition to its constructor.
+ * Call [write] passing it the conditional mutation.
+ * Return `true` if [getStatus] from the [Result] returned by [write] is [ACCEPTED].
+
+[ConditionalWriter]: {% jurl org.apache.accumulo.core.client.ConditionalWriter %}
+[Result]: {% jurl org.apache.accumulo.core.client.ConditionalWriter.Result %}
+[createConditionalWriter]: {% jurl org.apache.accumulo.core.client.Connector#createConditionalWriter-java.lang.String-org.apache.accumulo.core.client.ConditionalWriterConfig- %}
+[Condition]: {% jurl org.apache.accumulo.core.data.Condition %}
+[ConditionalMutation]: {% jurl org.apache.accumulo.core.data.ConditionalMutation %}
+[getStatus]: {% jurl org.apache.accumulo.core.client.ConditionalWriter.Result#getStatus-- %}
+[write]: {% jurl org.apache.accumulo.core.client.ConditionalWriter#write-org.apache.accumulo.core.data.ConditionalMutation- %}
+[setValue]: {% jurl org.apache.accumulo.core.data.Condition#setValue-java.lang.CharSequence- %}
+[ACCEPTED]: {% jurl org.apache.accumulo.core.client.ConditionalWriter.Status#ACCEPTED %}

--- a/tour-jshell/data-model-code2.md
+++ b/tour-jshell/data-model-code2.md
@@ -1,0 +1,75 @@
+---
+title: Data Model Code
+---
+
+Below is the solution for the complete exercise.
+
+```commandline
+jshell> client.tableOperations().create("GothamPD");
+```
+Create a row for Batman
+```commandline
+jshell> Mutation mutation1 = new Mutation("id0001");
+mutation1 ==> org.apache.accumulo.core.data.Mutation@1
+
+jshell> mutation1.put("hero","alias", "Batman");
+jshell> mutation1.put("hero","name", "Bruce Wayne");
+jshell> mutation1.put("hero","wearsCape?", "true");
+```
+
+Create a row for Robin
+```commandline
+jshell> Mutation mutation2 = new Mutation("id0002");
+mutation2 ==> org.apache.accumulo.core.data.Mutation@1
+
+jshell> mutation2.put("hero","alias", "Robin");
+jshell> mutation2.put("hero","name", "Dick Grayson");
+jshell> mutation2.put("hero","wearsCape?", "true");
+```    
+
+Create a row for Joker
+```commandline
+jshell> Mutation mutation3 = new Mutation("id0003");
+mutation3 ==> org.apache.accumulo.core.data.Mutation@1
+
+jshell> mutation3.put("villain","alias", "Joker");
+jshell> mutation3.put("villain","name", "Unknown");
+jshell> mutation3.put("villain","wearsCape?", "false");
+```
+
+Create a BatchWriter to the GothamPD table and add your mutations to it.
+Once the BatchWriter is closed by the try-with-resources, data will be available to scans.
+
+```commandline
+jshell> try (BatchWriter writer = client.createBatchWriter("GothamPD")) {
+   ...>   writer.addMutation(mutation1);
+   ...>   writer.addMutation(mutation2);
+   ...>   writer.addMutation(mutation3);
+   ...> }
+```
+
+Read and print all rows of the "GothamPD" table. Try-with-resources will close for us.
+
+Note: A Scanner is an extension of ```java.lang.Iterable``` so it will traverse through the table.
+
+```commandline
+jshell> try (ScannerBase scan = client.createScanner("GothamPD", Authorizations.EMPTY)) {
+   ...>   System.out.println("Gotham Police Department Persons of Interest:");
+   ...>     for (Map.Entry<Key, Value> entry : scan) {
+   ...>     System.out.printf("Key : %-50s  Value : %s\n", entry.getKey(), entry.getValue());
+   ...>   }
+   ...> }
+Gotham Police Department Persons of Interest:
+Key : id0001 hero:alias [] 1511306370025 false            Value : Batman
+Key : id0001 hero:name [] 1511306370025 false             Value : Bruce Wayne
+Key : id0001 hero:wearsCape? [] 1511306370025 false       Value : true
+Key : id0002 hero:alias [] 1511306370025 false            Value : Robin
+Key : id0002 hero:name [] 1511306370025 false             Value : Dick Grayson
+Key : id0002 hero:wearsCape? [] 1511306370025 false       Value : true
+Key : id0003 villain:alias [] 1511306370025 false         Value : Joker
+Key : id0003 villain:name [] 1511306370025 false          Value : Unknown
+Key : id0003 villain:wearsCape? [] 1511306370025 false    Value : false
+```
+Timestamps will differ.
+
+

--- a/tour-jshell/data-model2.md
+++ b/tour-jshell/data-model2.md
@@ -1,0 +1,39 @@
+---
+title: Data Model
+---
+
+Data is stored in Accumulo in a distributed sorted map. The `Key's` of the map are broken up logically 
+into a few different parts, as seen in the image below.
+
+![key value pair]({{ site.baseurl }}/images/docs/key_value.png)
+
+<br/>
+
+| **Row ID** | Unique identifier for the row |
+| **Column Family** | Logical grouping of the key. This field can be used to partition data within a node |
+| **Column Qualifier** | More specific attribute of the key |
+| **Column Visibility** | Security label controlling access to the key/value pair |
+| **Timestamp** | Generated automatically and used for versioning |
+
+The **value** is where the actual data is stored. For brevity, we often refer to the 3 parts of the 
+column as the family, qualifier, and visibility.
+
+Take a closer look at the Mutation object created in the first exercise:
+```commandline
+Mutation mutation1 = new Mutation("id0001");
+mutation1.put("hero","alias", "Batman");
+```
+It can be broken down as follows: <br/>
+
+| **Row ID**: | id0001 |
+| **Column Family**: | hero |  
+| **Column Qualifier**: | alias |
+| **Value**: | Batman |
+
+As an exercise, add a few more rows to the GothamPD table.  Create a row for Robin (id0002), who is a 
+hero that also wears a cape and his name is "Dick Grayson".  Create a row for Joker (id0003), who is 
+a villain with an "Unknown" name and doesn't wear a cape. Compare your output to the output displayed 
+on the next page.
+
+Notice how the data is printed in sorted order. Accumulo sorts by Row ID, then Family, and then 
+Qualifier.

--- a/tour-jshell/getting-started2.md
+++ b/tour-jshell/getting-started2.md
@@ -1,0 +1,129 @@
+---
+title: Getting Started
+---
+
+To complete the tour you will need a running Accumulo instance. If you do not have access to an 
+Accumulo cluster you can use [fluo-uno] to set up a single node instance for use with the Tour.
+
+Once you have an instance up and running, start the Accumulo JShell interface by typing the command 
+below. The '$' represents the system prompt.
+
+```commandline
+$ accumulo jshell
+```
+
+This will present you with a Java JShell interface with the required Accumulo libraries pre-loaded 
+and a working Accumulo ```client``` object.
+
+```commandline
+Preparing JShell for Apache Accumulo
+
+Use 'client' to interact with Accumulo
+
+|  Welcome to JShell -- Version 11
+|  For an introduction type: /help intro
+
+jshell>
+```
+
+JShell has a few commands that can be helpful.
+
+`/imports` lists the currently loaded imports in the JShell session.
+
+```commandline
+jshell> /imports
+|    import java.io.*
+|    import java.math.*
+|    import java.net.*
+|    import java.nio.file.*
+|    import java.util.*
+|    import java.util.concurrent.*
+|    import java.util.function.*
+|    import java.util.prefs.*
+|    import java.util.regex.*
+|    import java.util.stream.*
+|    import org.apache.accumulo.core.client.*
+|    import org.apache.accumulo.core.client.admin.*
+|    import org.apache.accumulo.core.client.admin.compaction.*
+|    import org.apache.accumulo.core.client.lexicoder.*
+|    import org.apache.accumulo.core.client.mapred.*
+|    import org.apache.accumulo.core.client.mapreduce.*
+|    import org.apache.accumulo.core.client.mapreduce.lib.partition.*
+|    import org.apache.accumulo.core.client.replication.*
+|    import org.apache.accumulo.core.client.rfile.*
+|    import org.apache.accumulo.core.client.sample.*
+|    import org.apache.accumulo.core.client.security.*
+|    import org.apache.accumulo.core.client.security.tokens.*
+|    import org.apache.accumulo.core.client.summary.*
+|    import org.apache.accumulo.core.client.summary.summarizers.*
+|    import org.apache.accumulo.core.data.*
+|    import org.apache.accumulo.core.data.constraints.*
+|    import org.apache.accumulo.core.security.*
+|    import org.apache.accumulo.minicluster.*
+|    import org.apache.accumulo.hadoop.mapreduce.*
+|    import org.apache.accumulo.hadoop.mapreduce.partition.*
+|    import org.apache.hadoop.io.Text
+```
+
+`/vars` will display all currently defined variables.
+
+```commandline
+jshell> /vars
+|    URL clientPropUrl = file:<path_to_accumulo_dir>/conf/accumulo-client.properties
+|    AccumuloClient client = org.apache.accumulo.core.clientImpl.ClientContext@7cbee484
+```
+
+`/list` displays all user defined code snippets. 
+
+`/list <id>` displays the snippet with the specified id. 
+
+`/list <name>` displays the snippet with the specified name.
+
+`/<id>` will re-run the snippet with the given id. 
+
+For example:
+
+```commandline
+jshell> var x = 12;
+x ==> 12
+
+jshell> var y = 23;
+y ==> 23
+
+jshell> int add(int x, int y) {
+   ...>   return x + y;
+   ...> }
+|  created method add(int,int)
+
+jshell> add(4,5);
+$6 ==> 9      
+
+jshell> /list
+
+   1 : System.out.println("Preparing JShell for Apache Accumulo");
+   2 : var x = 12;
+   3 : var y = 23;
+   4 : int add(int x, int y) {
+         return x + y;
+       }
+
+ jshell> /list add
+
+   5 : int add(int x, int y) {
+         return x + y;
+       }
+
+jshell> /list 4
+
+   4 : int add(int x, int y) {
+         return x + y;
+       }
+       
+jshell> /4
+add(4,5);
+$8 ==> 9
+```
+
+Ok, let's go!
+
+[fluo-uno]: https://github.com/apache/fluo-uno

--- a/tour-jshell/index.md
+++ b/tour-jshell/index.md
@@ -1,15 +1,15 @@
 ---
 title: Accumulo Tour
 layout: page
-permalink: /tour/
+permalink: /tour-jshell/
 skiph1fortitle: true
 ---
 
-{% assign tour_pages = site.data.tour.docs %}
-{% assign first_url = tour_pages[0] | prepend: '/tour/' | append: '/' %}
+{% assign tour_pages = site.data.tour-jshell.docs %}
+{% assign first_url = tour_pages[0] | prepend: '/tour-jshell/' | append: '/' %}
 {% assign first_page = site.pages | where:'url',first_url | first %}
 
-Welcome to the MiniAccumuloCluster version of the Accumulo tour! When on a tour page, the left and 
+Welcome to the JShell version of the Accumulo tour! When on a tour page, the left and
 right keys on the keyboard can be used to navigate. The tour begins at the
 [{{ first_page.title }}]({{ first_url }}) page.
 
@@ -17,7 +17,7 @@ If you have any questions or suggestions while
 going through the tour, please email our [mailing list][mlist] or [create an issue][issue].
 
 {% for p in tour_pages %}
-  {% assign doc_url = p | prepend: '/tour/' | append: '/' %}
+  {% assign doc_url = p | prepend: '/tour-jshell/' | append: '/' %}
   {% assign link_to_page = site.pages | where:'url',doc_url | first %}
   1. [{{ link_to_page.title }}]({{ doc_url }})
 {% endfor %}

--- a/tour-jshell/ranges-splits2.md
+++ b/tour-jshell/ranges-splits2.md
@@ -1,0 +1,44 @@
+---
+title: Ranges and Splits
+---
+
+A [Range] is a specified group of `Key`s. There are many ways to create a `Range`.  Here are a few examples:
+
+```commandline
+Range r1 = new Range(startKey, endKey);  // Creates a range from startKey inclusive to endKey inclusive.
+Range r2 = new Range(row);               // Creates a range that covers an entire row.
+Range r3 = new Range(startRow, endRow);  // Creates a range from startRow inclusive to endRow inclusive.
+```
+
+A `Scanner` by default will scan all ```Key```'s in a table but this can be inefficient. It is a good practice to
+set a range on a Scanner.
+
+```commandline
+scanner.setRange(new Range("id0000", "id0010"));  // returns rows from id0000 to id0010
+```
+
+As your data grows larger, Accumulo will split tables into smaller pieces called ```Tablet```'s which can
+be distributed across multiple Tablet Servers. By default, a table will get split into `Tablet`s on
+row boundaries, guaranteeing an entire row will be on one Tablet Server.  We have the ability to
+tell Accumulo where to split tables by setting split points. This is done using `addSplits` in the 
+[TableOperations] API.  The image below demonstrates how Accumulo splits data.
+
+![data distribution]({{ site.baseurl }}/images/docs/data_distribution.png)
+
+Take a minute to learn these Accumulo terms:
+<br/>
+
+| **Tablet** | A partition of a table |
+| **Split** | A point where tables are partitioned into separate tablets |
+| **Flush** | Action taken when data is written from memory to disk |
+| **Compact** | Action taken when files on disk are consolidated |
+| **Iterator** | A server side mechanism that can filter and modify Key/Value pairs |
+
+Knowing these terms are critical when working closely with Accumulo.  Iterators are especially unique 
+and powerful.  More on them later.
+
+When working with large amounts of data across many 'Tablet Server's, a simple Scanner might not do the trick. 
+Next lesson we learn about the power of the multithreaded `BatchScanner`!
+
+[Range]: {% jurl org.apache.accumulo.core.data.Range %}
+[TableOperations]: {% jurl org.apache.accumulo.core.client.admin.TableOperations %}

--- a/tour-jshell/using-iterators2.md
+++ b/tour-jshell/using-iterators2.md
@@ -1,0 +1,141 @@
+---
+title: Using Iterators
+---
+
+Suppose at the end of each day we record the number of villains a hero has caught that day. Iterators
+can assist with this. Iterators are server-side programming mechanisms that allow filtering and
+aggregation operations on data during scans and during compactions.
+
+Let's begin by adding some data for our hero's recording recent crime-stopping statistics.
+
+```commandlne
+jshell> client.tableOperations().create("GothamCrimeStats");
+
+jshell> Mutation mutation1 = new Mutation("id0001");
+mutation1 ==> org.apache.accumulo.core.data.Mutation@1
+jshell> mutation1.put("hero", "alias", "Batman");
+
+// last three days of Batman's statistics
+jshell> mutation1.put("hero", "villainsCaptured", "2");
+jshell> mutation1.put("hero", "villainsCaptured", "1");
+jshell> mutation1.put("hero", "villainsCaptured", "5");
+
+jshell> Mutation mutation2 = new Mutation("id0002");
+mutation2 ==> org.apache.accumulo.core.data.Mutation@1
+jshell> mutation2.put("hero", "alias", "Robin");
+
+// last three days of Robin's statistics
+jshell> mutation2.put("hero", "villainsCaptured", "1");
+jshell> mutation2.put("hero", "villainsCaptured", "0");
+jshell> mutation2.put("hero", "villainsCaptured", "2");
+
+jshell> try (BatchWriter writer = client.createBatchWriter("GothamCrimeStats")) {
+   ...>   writer.addMutation(mutation1);
+   ...>   writer.addMutation(mutation2);
+   ...> }
+```
+
+Let's scan to see the data. 
+
+```commandline
+jshell> try (ScannerBase scan = client.createScanner("GothamCrimeStats", Authorizations.EMPTY)) {
+   ...>   System.out.println("Gotham Police Department Crime Statistics:");
+   ...>   for(Map.Entry<Key, Value> entry : scan) {
+   ...>     System.out.printf("Key : %-52s  Value : %s\n", entry.getKey(), entry.getValue());
+   ...>   }
+   ...> }
+```   
+
+You may notice a problem. We only see the latest entry. That is due to the
+`versioningIterator` which is applied to all tables by default. It filters out all but the latest entry
+when scanning a table. 
+
+In order to see a record of past days we can remove the `versioningiterator` (you could also choose
+a set number of past entries to display). The iterator is named `vers`.
+
+To simplify, we will import some additional packages to save some typing.
+
+```commandline
+jshell> import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
+jshell> client.tableOperations().removeIterator("GothamCrimeStats", "vers", EnumSet.allOf(IteratorScope.class));
+```
+
+Now let's scan again.
+
+```commandline
+jshell> try (ScannerBase scan = client.createScanner("GothamCrimeStats", Authorizations.EMPTY)) {
+   ...>   System.out.println("Gotham Police Department Crime Statistics:");
+   ...>   for(Map.Entry<Key, Value> entry : scan) {
+   ...>     System.out.printf("Key : %-52s  Value : %s\n", entry.getKey(), entry.getValue());
+   ...>   }
+   ...> }   
+Gotham Police Department Crime Statistics:
+Key : id0001 hero:alias [] 1654697915769 false              Value : Batman
+Key : id0001 hero:villainsCaptured [] 1654697915769 false   Value : 5
+Key : id0001 hero:villainsCaptured [] 1654697915769 false   Value : 1
+Key : id0001 hero:villainsCaptured [] 1654697915769 false   Value : 2
+Key : id0002 hero:alias [] 1654697915769 false              Value : Robin
+Key : id0002 hero:villainsCaptured [] 1654697915769 false   Value : 2
+Key : id0002 hero:villainsCaptured [] 1654697915769 false   Value : 0
+Key : id0002 hero:villainsCaptured [] 1654697915769 false   Value : 1
+```
+ 
+You will now see ALL entries added to the table.
+
+Instead of seeing a daily history, let's instead keep a running total of captured villains. 
+A `summingcombiner` can be used to accomplish this.
+
+```commandline
+jshell> import org.apache.accumulo.core.iterators.user.SummingCombiner;
+jshell> import org.apache.accumulo.core.iterators.LongCombiner
+```
+
+Create an IteratorSetting object. Set the encoding type and indicate the columns to be summed.
+Also, it is a good idea to check for any iterator conflicts prior to attaching the iterator to the 
+table.
+
+```commandline
+jshell> IteratorSetting scSetting = new IteratorSetting(30, "sum", SummingCombiner.class);
+jshell> LongCombiner.setEncodingType(scSetting, LongCombiner.Type.STRING);
+jshell> scSetting.addOption("columns", "hero:villainsCaptured");
+jshell> client.tableOperations().checkIteratorConflicts("GothamCrimeStats", scSetting, EnumSet.allOf(IteratorScope.class));
+jshell> client.tableOperations().attachIterator("GothamCrimeStats", scSetting);
+```
+
+Let's scan again and see what results we get.
+
+```commandline
+jshell> try ( org.apache.accumulo.core.client.Scanner scan = client.createScanner("GothamCrimeStats", Authorizations.EMPTY)) {
+   ...>   for(Map.Entry<Key, Value> entry : scan) {
+   ...>     System.out.printf("Key : %-52s  Value : %s\n", entry.getKey(), entry.getValue());
+   ...>   }
+   ...> }
+Key : id0001 hero:alias [] 1654699186182 false              Value : Batman
+Key : id0001 hero:villainsCaptured [] 1654699186182 false   Value : 8
+Key : id0002 hero:alias [] 1654699186182 false              Value : Robin
+Key : id0002 hero:villainsCaptured [] 1654699186182 false   Value : 3
+```
+
+Adding additional statistics will result in a continual update of the relevant statistic.
+
+```commandline
+jshell> mutation1 = new Mutation("id0001");
+jshell> mutation1.put("hero", "villainsCaptured", "4");
+jshell> mutation2 = new Mutation("id0002");
+jshell> mutation2.put("hero", "villainsCaptured", "2");
+
+jshell> try (BatchWriter writer = client.createBatchWriter("GothamCrimeStats")) {
+   ...>   writer.addMutation(mutation1);
+   ...>   writer.addMutation(mutation2);
+   ...> }
+
+jshell> try ( org.apache.accumulo.core.client.Scanner scan = client.createScanner("GothamCrimeStats", Authorizations.EMPTY)) {
+   ...>   for(Map.Entry<Key, Value> entry : scan) {
+   ...>     System.out.printf("Key : %-52s  Value : %s\n", entry.getKey(), entry.getValue());
+   ...>   }
+   ...> }
+Key : id0001 hero:alias [] 1654779673027 false              Value : Batman
+Key : id0001 hero:villainsCaptured [] 1654780041402 false   Value : 12
+Key : id0002 hero:alias [] 1654779673027 false              Value : Robin
+Key : id0002 hero:villainsCaptured [] 1654780041402 false   Value : 5
+```


### PR DESCRIPTION
Added a version of the Accumulo Tour that makes use of the JShell feature of Accumulo 2.1.x. The user will have to option to go through the tour using the former version with the MiniAccumuloCluster or the newer JShell feature.

Also added a new page to the tour illustrating iterators.