### PR TITLE
Update 1.10.2 release notes for apache/accumulo#2775

### DIFF
--- a/_posts/release/2022-02-13-accumulo-1.10.2.md
+++ b/_posts/release/2022-02-13-accumulo-1.10.2.md
@@ -49,6 +49,25 @@ See the note in the 1.10.1 release notes about the use of JDK 15 or later, as
 the information pertaining to the use of the CMS garbage collector remains
 applicable to this version.
 
+## Known Issues
+
+* {% ghi 2775 %} Some users have reported problems with VFS-683, found in
+  commons-vfs2 version 2.3, which is bundled by default in Accumulo 1.10.2's
+  binary tarball distribution, and have reported more success with commons-vfs2
+  version 2.1, which can be substituted on the class path instead. The Accumulo
+  team cannot know which version will work best for your particular
+  environment, as version 2.1 also seems to have some bugs that you may
+  encounter. We cannot recommend one version over another for your specific
+  situation. If users wish to avoid using the dynamic class loading and remote
+  file system class loading features that commons-vfs2 empowers in Accumulo,
+  they can use local class paths only in their runtime environment, and solve
+  class path management synchronization issues on a cluster in other ways, such
+  as using a script to rsync dependencies prior to the launching the Accumulo
+  processes. Using rsync is only one possibility, and may not be suitable for
+  you. Consider reaching out to our user mailing list for ideas and
+  recommendations from other users.
+
+
 ## Useful Links
 
 * [Release VOTE email thread][vote-emails]


### PR DESCRIPTION
Add known issues section to 1.10.2 release notes and add information about potential commons-vfs2 pitfalls and workarounds.