### PR TITLE
Increase build timeout to 15 minutes

### DIFF
--- a/.github/workflows/jekyll.yaml
+++ b/.github/workflows/jekyll.yaml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   jekyll:
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -54,4 +54,3 @@ jobs:
         name: site
         path: ./_site/
         if-no-files-found: ignore
-


### PR DESCRIPTION
I've seen a couple of the QA builds timeout with only 10 minutes due to the test site part of the build taking a bit longer than usual. The jobs would have completed but timed out at 10 minutes (were around 80% done the upload part of the build).  Examples:

https://github.com/apache/accumulo-website/actions/runs/3256658816/attempts/1
https://github.com/apache/accumulo-website/actions/runs/3245360886