### PR TITLE
Bump GitHub Actions versions

### DIFF
--- a/.github/workflows/jekyll.yaml
+++ b/.github/workflows/jekyll.yaml
@@ -30,13 +30,13 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
     - name: Cache gems
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/vendor/bundle
         key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
@@ -49,7 +49,7 @@ jobs:
         bundle install --jobs 4 --retry 3
         bundle exec jekyll build
     - name: Upload site
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: site
         path: ./_site/


### PR DESCRIPTION
* Migrate from deprecated actions/setup-ruby to ruby/setup-ruby