### PR TITLE
Add zoo-info-viewer --print-acls usage, document expected ZooKeeper ACLs

### DIFF
--- a/_docs-2/administration/upgrading.md
+++ b/_docs-2/administration/upgrading.md
@@ -19,7 +19,9 @@ The basic upgrade sequence is:
 - stop Accumulo 1.10 or 2.0
 - prepare your installation of Accumulo 2.1 through whatever means you obtain the binaries and
   configure it in your environment
+- start ZooKeeper and HDFS.
 - (optional - but recommended) create a ZooKeeper snapshot
+- (optional - but recommended) validate the ZooKeeper ACLs. See [ZooKeeper ACLs]({% durl troubleshooting/ZooKeeper#ACLs %})
 - (required if not using the provided scripts to start 2.1) run the `RenameMasterDirInZK` utility
 - (optional) run the pre-upgrade utility to convert the configuration in ZooKeeper
 - start Accumulo 2.1 for the first time to complete the upgrade

--- a/_docs-2/troubleshooting/tools.md
+++ b/_docs-2/troubleshooting/tools.md
@@ -295,6 +295,7 @@ To run the command:
     --print-instances
     --print-id-map
     --print-props [--system] [-ns | --namespaces list] [-t | --tables list]
+    --print-acls
 
 ## mode: print instances
 The instance name(s) and instance id(s) are stored in ZooKeeper. To see the available name to id mapping run:
@@ -396,3 +397,39 @@ table.iterator.majc.vers=20,org.apache.accumulo.core.iterators.user.VersioningIt
 ...
 -----------------------------------------------
 ```
+
+## mode: print ACLs
+
+With 2.1.1, the `zoo-info-viewer` option `--print-acls` will print the ZooKeeper ACLs for all nodes under
+the `/accumulo/INSTANCE_ID]` path.
+
+See [troubleshooting ZooKeeper] for more information on the tool output and expected ACLs.
+
+```
+$ accumulo zoo-info-viewer  --print-acls
+
+-----------------------------------------------
+Report Time: 2023-01-27T23:00:26.079546Z
+-----------------------------------------------
+Output format:
+ACCUMULO_PERM:OTHER_PERM path user_acls...
+
+ZooKeeper acls for instance ID: f491223b-1413-494e-b75a-c2ca018db00f
+
+ACCUMULO_OKAY:NOT_PRIVATE /accumulo/f491223b-1413-494e-b75a-c2ca018db00f cdrwa:accumulo, r:anyone
+ACCUMULO_OKAY:NOT_PRIVATE /accumulo/f491223b-1413-494e-b75a-c2ca018db00f/bulk_failed_copyq cdrwa:accumulo, r:anyone
+ACCUMULO_OKAY:NOT_PRIVATE /accumulo/f491223b-1413-494e-b75a-c2ca018db00f/bulk_failed_copyq/locks cdrwa:accumulo, r:anyone
+ACCUMULO_OKAY:NOT_PRIVATE /accumulo/f491223b-1413-494e-b75a-c2ca018db00f/compactors cdrwa:accumulo, r:anyone
+ACCUMULO_OKAY:PRIVATE /accumulo/f491223b-1413-494e-b75a-c2ca018db00f/config cdrwa:accumulo
+ACCUMULO_OKAY:NOT_PRIVATE /accumulo/f491223b-1413-494e-b75a-c2ca018db00f/coordinators cdrwa:accumulo, r:anyone
+...
+ERROR_ACCUMULO_MISSING_SOME:NOT_PRIVATE /accumulo/f491223b-1413-494e-b75a-c2ca018db00f/users/root/Namespaces r:accumulo, r:anyone
+...
+ACCUMULO_OKAY:NOT_PRIVATE /accumulo/f491223b-1413-494e-b75a-c2ca018db00f/wals/localhost:9997[100003d35cc0004]/643b14db-b929-4570-b226-620bc5ac85ff cdrwa:accumulo, r:anyone
+ACCUMULO_OKAY:NOT_PRIVATE /accumulo/f491223b-1413-494e-b75a-c2ca018db00f/wals/localhost:9997[100003d35cc0004]/ad26be2a-dc52-4e0e-8e78-8fc8c3323d51 cdrwa:accumulo, r:anyone
+ACCUMULO_OKAY:NOT_PRIVATE /accumulo/instances cdrwa:anyone
+ACCUMULO_OKAY:NOT_PRIVATE /accumulo/instances/uno cdrwa:accumulo, r:anyone
+
+```
+
+[troubleshooting ZooKeeper]: {% durl troubleshooting/zookeeper %}

--- a/_docs-2/troubleshooting/tools.md
+++ b/_docs-2/troubleshooting/tools.md
@@ -398,7 +398,7 @@ table.iterator.majc.vers=20,org.apache.accumulo.core.iterators.user.VersioningIt
 -----------------------------------------------
 ```
 
-## mode: print ACLs
+## mode: print ACLs (new in 2.1.1)
 
 With 2.1.1, the `zoo-info-viewer` option `--print-acls` will print the ZooKeeper ACLs for all nodes under
 the `/accumulo/INSTANCE_ID]` path.

--- a/_docs-2/troubleshooting/zookeeper.md
+++ b/_docs-2/troubleshooting/zookeeper.md
@@ -12,7 +12,7 @@ To run the utility, only ZooKeeper needs to be running. If hdfs is running, the 
 or it can be entered with the zoo-info-viewer command --instanceId option.  Accumulo management processes 
 *do not* need to be running. This allows checking the ACLs before starting an upgrade. 
 
-The utility prints out two summarized fields related to ZooKeeper ACL permissions:
+The utility prints out a line for each znode that contains two fields related to ZooKeeper ACL permissions:
    - `[ACCUMULO_OKAY | ERROR_ACCUMULO_MISSING_SOME]` - Are the permissions sufficient for Accumulo to operate 
    - `[PRIVATE | NOT_PRIVATE]` - Can other users can read data from the ZooKeeper nodes.
 

--- a/_docs-2/troubleshooting/zookeeper.md
+++ b/_docs-2/troubleshooting/zookeeper.md
@@ -10,13 +10,22 @@ ZooKeeper cli `getAcl` and modified with `setAcl` commands.  With 2.1.1, the zoo
 that will print all of the ACLs for the nodes under `/accumulo/[INSTANCE_ID]` (See [zoo-info-viewer]).  
 To run the utility, only ZooKeeper needs to be running. If hdfs is running, the instance id can be read from hdfs, 
 or it can be entered with the zoo-info-viewer command --instanceId option.  Accumulo management processes 
-*do not* need to be running. This allows checking the ACLs before starting an upgrade. 
+*do not* need to be running. This allows checking the ACLs before starting an upgrade.
 
+The utility also prints the same permissions and user strings as the ZooKeeper cli getAcl command, so you can
+fully evaluate the permissions in the context of your needs.  
+
+Sample output (See the [zoo-info-viewer] tools documentation for a more complete sample):
+```
+ACCUMULO_OKAY:NOT_PRIVATE /accumulo/f491223b-1413-494e-b75a-c2ca018db00f cdrwa:accumulo, r:anyone
+ACCUMULO_OKAY:PRIVATE /accumulo/f491223b-1413-494e-b75a-c2ca018db00f/config cdrwa:accumulo
+ERROR_ACCUMULO_MISSING_SOME:NOT_PRIVATE /accumulo/f491223b-1413-494e-b75a-c2ca018db00f/users/root/Namespaces r:accumulo, r:anyone
+```
 The utility prints out a line for each znode that contains two fields related to ZooKeeper ACL permissions:
    - `[ACCUMULO_OKAY | ERROR_ACCUMULO_MISSING_SOME]` - Are the permissions sufficient for Accumulo to operate 
    - `[PRIVATE | NOT_PRIVATE]` - Can other users can read data from the ZooKeeper nodes.
 
-Nodes marked with `ERROR_ACCUMULO_MISSING_SOME` means that Accumulo does not have `cdrwa` permissions.
+Nodes marked with `ERROR_ACCUMULO_MISSING_SOME` shows that Accumulo does not have `cdrwa` permissions.
 Without full permissions, the upgrade will fail checks. The node permissions need to be corrected with the ZooKeeper
 `setAcl` command.  If you do not have sufficient permissions to change the ACLs on a node, see the section 
 below, [ACL errors during upgrade]({% durl troubleshooting/zookeeper/ACL#errors#during#upgrade %}).

--- a/_docs-2/troubleshooting/zookeeper.md
+++ b/_docs-2/troubleshooting/zookeeper.md
@@ -16,7 +16,7 @@ The utility prints out a line for each znode that contains two fields related to
    - `[ACCUMULO_OKAY | ERROR_ACCUMULO_MISSING_SOME]` - Are the permissions sufficient for Accumulo to operate 
    - `[PRIVATE | NOT_PRIVATE]` - Can other users can read data from the ZooKeeper nodes.
 
-If there are nodes with `ERROR_ACCUMULO_MISSING_SOME` are nodes where Accumulo does not have `cdrwa` permissions.
+Nodes marked with `ERROR_ACCUMULO_MISSING_SOME` means that Accumulo does not have `cdrwa` permissions.
 Without full permissions, the upgrade will fail checks. The node permissions need to be corrected with the ZooKeeper
 `setAcl` command.  If you do not have sufficient permissions to change the ACLs on a node, see the section 
 below, [ACL errors during upgrade]({% durl troubleshooting/zookeeper/ACL#errors#during#upgrade %}).

--- a/_docs-2/troubleshooting/zookeeper.md
+++ b/_docs-2/troubleshooting/zookeeper.md
@@ -3,6 +3,34 @@ title: ZooKeeper
 category: troubleshooting
 order: 7
 ---
+## ZooKeeper ACLs
+
+Accumulo requires full access to nodes in ZooKeeper under the /accumulo path.  The ACLs can be examined using the
+ZooKeeper cli `getAcl` and modified with `setAcl` commands.  With 2.1.1, the zoo-info-viewer utility has an option
+that will print all of the ACLs for the nodes under `/accumulo/[INSTANCE_ID]` (See the [zoo-info-viewer]).  
+To run the utility, only ZooKeeper needs to be running. If hdfs is running, the instance id can be read from hdfs, 
+or it can be entered with the zoo-info-viewer command --instanceId option.  Accumulo management processes 
+*do not* need to be running. This allows checking the ACLs before starting an upgrade. 
+
+The utility prints out two summarized fields related to ZooKeeper ACL permissions:
+   - `[ACCUMULO_OKAY | ERROR_ACCUMULO_MISSING_SOME]` - Are the permissions sufficient for Accumulo to operate 
+   - `[PRIVATE | NOT_PRIVATE]` - Can other users can read data from the ZooKeeper nodes.
+
+If there are nodes with `ERROR_ACCUMULO_MISSING_SOME` are nodes where Accumulo does not have `cdrwa` permissions.
+Without full permissions, the upgrade will fail checks. The node permissions need to be corrected with the ZooKeeper
+`setAcl` command.  If you do not have sufficient permissions to change the ACLs on a node, see the section 
+below, [ACL errors during upgrade]({% durl troubleshooting/zookeeper/ACL#errors#during#upgrade %}).
+
+Most Accumulo nodes do not contain sensitive data. Allowing unauthenticated ZooKeeper client(s) to read values is 
+not unusual in typical deployments. The exception to a permissive read policy are the nodes that store configuration 
+and properties (generally, nodes named `../config`). Because property values may be sensitive, access should be
+restricted to authenticated Accumulo clients.  The tool will mark those nodes as `PRIVATE`.
+
+Allowing users other than authenticated Accumulo clients to write or modify nodes is not recommended.
+
+The utility also prints the same permissions and user strings as the ZooKeeper cli getAcl command, so you can 
+fully evaluate the permissions in the context of your needs.  See the [zoo-info-viewer] tools documentation 
+for sample output.
 
 ## ACL errors during upgrade
 
@@ -23,4 +51,5 @@ Manual intervention is required in the event that an upgrade fails due to unexpe
     6. Then, correct the ACL on the znode using the command `setAcl -R <path> world:anyone:r,auth:accumulo:cdrwa`
 
 [option]: https://zookeeper.apache.org/doc/r3.5.2-alpha/zookeeperAdmin.html#sc_authOptions
+[tools-info-viewer]: {% durl troubleshooting/tools#mode-print-ACLs %}
 

--- a/_docs-2/troubleshooting/zookeeper.md
+++ b/_docs-2/troubleshooting/zookeeper.md
@@ -7,7 +7,7 @@ order: 7
 
 Accumulo requires full access to nodes in ZooKeeper under the /accumulo path.  The ACLs can be examined using the
 ZooKeeper cli `getAcl` and modified with `setAcl` commands.  With 2.1.1, the zoo-info-viewer utility has an option
-that will print all of the ACLs for the nodes under `/accumulo/[INSTANCE_ID]` (See the [zoo-info-viewer]).  
+that will print all of the ACLs for the nodes under `/accumulo/[INSTANCE_ID]` (See [zoo-info-viewer]).  
 To run the utility, only ZooKeeper needs to be running. If hdfs is running, the instance id can be read from hdfs, 
 or it can be entered with the zoo-info-viewer command --instanceId option.  Accumulo management processes 
 *do not* need to be running. This allows checking the ACLs before starting an upgrade. 


### PR DESCRIPTION
- Add info for zoo-info-viewer --print-acls with output sample
- Updates ZooKeeper troubleshooting to include expected ACLs for Accumulo