### PR TITLE
Add documentation on how to launch fate admin command

### DIFF
--- a/_docs-2/administration/fate.md
+++ b/_docs-2/administration/fate.md
@@ -72,16 +72,14 @@ For example, a command that is not completing could be blocked on the execution 
 operation. Accumulo provides an Accumulo shell command to interact with fate.
 
 The `fate` admin command accepts a number of arguments for different functionality:
-`list`/`print`, `summary`, `cancel`, `fail`, `delete`, `dump`.
+`list`/`print`, `summary`, `cancel`, `fail`, `delete`, `dump`.  
 
-The command is launched using:
+The command for launching the fate admin command is:
 ```
 > accumulo admin fate --[option]
 ```
-help that lists the fate options (and other admin commands) is available using:
-```
-> accumulo admin -h
-```
+The Accumulo admin help command option `accumulo admin -h` shows the expected usage information for the fate and
+other admin commands.
 ### List/Print
 
 Without any additional arguments, this command will print all operations that still exist in

--- a/_docs-2/administration/fate.md
+++ b/_docs-2/administration/fate.md
@@ -79,8 +79,10 @@ The command for launching the fate admin command is:
 ```
 > accumulo admin fate --[option]
 ```
+
 The Accumulo admin help command option `accumulo admin -h` shows the expected usage information for the fate and
 other admin commands.
+
 ### List/Print
 
 Without any additional arguments, this command will print all operations that still exist in

--- a/_docs-2/administration/fate.md
+++ b/_docs-2/administration/fate.md
@@ -78,6 +78,10 @@ The command is launched using:
 ```
 > accumulo admin fate --[option]
 ```
+help that lists the fate options (and other admin commands) is available using:
+```
+> accumulo admin -h
+```
 ### List/Print
 
 Without any additional arguments, this command will print all operations that still exist in

--- a/_docs-2/administration/fate.md
+++ b/_docs-2/administration/fate.md
@@ -72,7 +72,7 @@ For example, a command that is not completing could be blocked on the execution 
 operation. Accumulo provides an Accumulo shell command to interact with fate.
 
 The `fate` admin command accepts a number of arguments for different functionality:
-`list`/`print`, `summary`, `cancel`, `fail`, `delete`, `dump`.  
+`list`/`print`, `summary`, `cancel`, `fail`, `delete`, `dump`.
 
 The command for launching the fate admin command is:
 ```

--- a/_docs-2/administration/fate.md
+++ b/_docs-2/administration/fate.md
@@ -71,9 +71,13 @@ Sometimes, it is useful to inspect the current FATE operations, both pending and
 For example, a command that is not completing could be blocked on the execution of another
 operation. Accumulo provides an Accumulo shell command to interact with fate.
 
-The `fate` shell command accepts a number of arguments for different functionality:
+The `fate` admin command accepts a number of arguments for different functionality:
 `list`/`print`, `summary`, `cancel`, `fail`, `delete`, `dump`.
 
+The command is launched using:
+```
+> accumulo admin fate --[option]
+```
 ### List/Print
 
 Without any additional arguments, this command will print all operations that still exist in

--- a/_docs-2/administration/fate.md
+++ b/_docs-2/administration/fate.md
@@ -75,6 +75,7 @@ The `fate` admin command accepts a number of arguments for different functionali
 `list`/`print`, `summary`, `cancel`, `fail`, `delete`, `dump`.
 
 The command for launching the fate admin command is:
+
 ```
 > accumulo admin fate --[option]
 ```


### PR DESCRIPTION
Looking at [ACCUMULO-2521](https://issues.apache.org/jira/browse/ACCUMULO-2521) realized we documented the FATE command options, but never explicitly detailed how to launch the command.