### PR TITLE
Fix broken links to Log config files

### DIFF
--- a/_docs-2/configuration/files.md
+++ b/_docs-2/configuration/files.md
@@ -36,16 +36,12 @@ Accumulo processes. See the [quick start] for help with configuring this file.
 
 ## Log configuration files
 
-### log4j-service.properties
+### log4j2-service.properties
 
 The {% ghc assemble/conf/log4j2-service.properties %} file configures logging for most Accumulo services
-(i.e [Manager], [Tablet Server], [Garbage Collector]) except for the Monitor.
+(i.e [Manager], [Tablet Server], [Garbage Collector], [Monitor]).
 
-### log4j-monitor.properties
-
-The `log4j2-monitor.properties` file configures logging for the [Monitor].
-
-### log4j.properties
+### log4j2.properties
 
 The {% ghc assemble/conf/log4j2.properties %} file configures logging for Accumulo commands (i.e `accumulo init`,
 `accumulo shell`, etc).

--- a/_docs-2/configuration/files.md
+++ b/_docs-2/configuration/files.md
@@ -38,8 +38,9 @@ Accumulo processes. See the [quick start] for help with configuring this file.
 
 ### log4j2-service.properties
 
-The {% ghc assemble/conf/log4j2-service.properties %} file configures logging for most Accumulo services
-(i.e [Manager], [Tablet Server], [Garbage Collector], [Monitor]).
+Since 2.1, the {% ghc assemble/conf/log4j2-service.properties %} file configures logging for most Accumulo services
+(i.e [Manager], [Tablet Server], [Garbage Collector], [Monitor]). Prior to 2.1 this file was named `log4j-service.properties`
+and did not apply to the [Monitor] which was configured in a separate `log4j-monitor.properties`.
 
 ### log4j2.properties
 

--- a/_docs-2/configuration/files.md
+++ b/_docs-2/configuration/files.md
@@ -38,16 +38,16 @@ Accumulo processes. See the [quick start] for help with configuring this file.
 
 ### log4j-service.properties
 
-The {% ghc assemble/conf/log4j-service.properties %} file configures logging for most Accumulo services
+The {% ghc assemble/conf/log4j2-service.properties %} file configures logging for most Accumulo services
 (i.e [Manager], [Tablet Server], [Garbage Collector]) except for the Monitor.
 
 ### log4j-monitor.properties
 
-The {% ghc assemble/conf/log4j-monitor.properties %} file configures logging for the [Monitor].
+The `log4j2-monitor.properties` file configures logging for the [Monitor].
 
 ### log4j.properties
 
-The {% ghc assemble/conf/log4j.properties %} file configures logging for Accumulo commands (i.e `accumulo init`,
+The {% ghc assemble/conf/log4j2.properties %} file configures logging for Accumulo commands (i.e `accumulo init`,
 `accumulo shell`, etc).
 
 ## cluster.yaml


### PR DESCRIPTION
The links are for 2.0.x and point to files that have been renamed or deleted with the 2.1.x release.

It seems that there's no longer an example configuration for the Monitor. I've assumed it's still possible to provide a specific config for this.