### PR TITLE
add confluence link to how-to-contribute page

### DIFF
--- a/pages/contact-us.md
+++ b/pages/contact-us.md
@@ -54,6 +54,11 @@ follow discussions as they happen.
 
 Drop by and chat about Accumulo at the [#accumulo][accumulo-channel] channel on the [ASF Slack workspace][asf-slack]. Join using this [invite link][slack-invite]. If you have trouble joining, email `dev@accumulo.apache.org` for an invite.
 
+## Confluence
+
+The [Accumulo Confluence Space][confluence] provides a collaboration space for design documents.  If you would like write 
+access, please send a request to `dev@accumulo.apache.org` with your Confluence username.
+
 ## Contributions
 
 Contributions to Apache Accumulo are welcome! If you are interested, read [how to contribute][contribute]. If you need help finding something to work on, send a message to our `dev` mailing list and we'll help you find a task that interests you.
@@ -94,3 +99,4 @@ Contributions to Apache Accumulo are welcome! If you are interested, read [how t
 [accumulo-channel]: https://the-asf.slack.com/messages/CERNB8NDC
 [slack-invite]: https://s.apache.org/slack-invite
 [contribute]: /how-to-contribute/
+[confluence]: https://cwiki.apache.org/confluence/display/ACCUMULO/Apache+Accumulo+Home

--- a/pages/contact-us.md
+++ b/pages/contact-us.md
@@ -54,11 +54,6 @@ follow discussions as they happen.
 
 Drop by and chat about Accumulo at the [#accumulo][accumulo-channel] channel on the [ASF Slack workspace][asf-slack]. Join using this [invite link][slack-invite]. If you have trouble joining, email `dev@accumulo.apache.org` for an invite.
 
-## Confluence
-
-The [Accumulo Confluence Space][confluence] provides a collaboration space for design documents.  If you would like write 
-access, please send a request to `dev@accumulo.apache.org` with your Confluence username.
-
 ## Contributions
 
 Contributions to Apache Accumulo are welcome! If you are interested, read [how to contribute][contribute]. If you need help finding something to work on, send a message to our `dev` mailing list and we'll help you find a task that interests you.

--- a/pages/contact-us.md
+++ b/pages/contact-us.md
@@ -94,4 +94,3 @@ Contributions to Apache Accumulo are welcome! If you are interested, read [how t
 [accumulo-channel]: https://the-asf.slack.com/messages/CERNB8NDC
 [slack-invite]: https://s.apache.org/slack-invite
 [contribute]: /how-to-contribute/
-[confluence]: https://cwiki.apache.org/confluence/display/ACCUMULO/Apache+Accumulo+Home

--- a/pages/how-to-contribute.md
+++ b/pages/how-to-contribute.md
@@ -31,11 +31,6 @@ Any questions/ideas don't hesitate to [contact us][contact].
 | [Proxy][p]         | [Issues][pi]                   | Apache Thrift service that exposes Accumulo to other languages |
 | [Maven plugin][m]  | [Issues][mi]                   | Maven plugin that runs Accumulo |
 
-## Confluence
-
-The [Accumulo Confluence Space][confluence] provides a collaboration space for design documents.  If you would like write
-access, please send a request to `dev@accumulo.apache.org` with your Confluence username.
-
 ## Example Contribution workflow
 
 1. Create a [GitHub account][github-join] for issues and pull requests.
@@ -68,10 +63,13 @@ access, please send a request to `dev@accumulo.apache.org` with your Confluence 
 
 * **Build resources** - [Jenkins][jenkins]
 * **Releases** - [Making a release][making], [Verifying a release][verifying]
+* **Confluence** - [Accumulo Confluence Space][confluence] provides a collaboration space for design documents.  If you would like write
+access, please send a request to `dev@accumulo.apache.org` with your Confluence username.
 
 For more information, see the [contributor guide](/contributors-guide/).
 
 [good-first-issue]: https://github.com/apache/accumulo/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+[confluence]: https://cwiki.apache.org/confluence/display/ACCUMULO/Apache+Accumulo+Home
 [contact]: /contact-us/
 [a]: https://github.com/apache/accumulo
 [ac]: https://github.com/apache/accumulo/blob/main/CONTRIBUTING.md

--- a/pages/how-to-contribute.md
+++ b/pages/how-to-contribute.md
@@ -8,7 +8,7 @@ Contributions are welcome to all Apache Accumulo repositories. While most contri
 there are other ways to contribute to Accumulo:
 
 * communicate on one of the [mailing lists](/contact-us/#mailing-lists)
-* participate in design discussions on [Confluence][confluence]
+* view/draft/comment on designs or other docs in [Confluence][confluence]
 * review [pull requests](https://github.com/apache/accumulo/pulls)
 * verify and test new [releases](/release/)
 * update the [Accumulo website and documentation](https://github.com/apache/accumulo-website)

--- a/pages/how-to-contribute.md
+++ b/pages/how-to-contribute.md
@@ -8,7 +8,7 @@ Contributions are welcome to all Apache Accumulo repositories. While most contri
 there are other ways to contribute to Accumulo:
 
 * communicate on one of the [mailing lists](/contact-us/#mailing-lists)
-* participate in design discussions on [Confluence](/#Confluence)
+* participate in design discussions on [Confluence][confluence]
 * review [pull requests](https://github.com/apache/accumulo/pulls)
 * verify and test new [releases](/release/)
 * update the [Accumulo website and documentation](https://github.com/apache/accumulo-website)

--- a/pages/how-to-contribute.md
+++ b/pages/how-to-contribute.md
@@ -63,8 +63,8 @@ Any questions/ideas don't hesitate to [contact us][contact].
 
 * **Build resources** - [Jenkins][jenkins]
 * **Releases** - [Making a release][making], [Verifying a release][verifying]
-* **Confluence** - [Accumulo Confluence Space][confluence] provides a collaboration space for design documents.  If you would like write
-access, please send a request to `dev@accumulo.apache.org` with your Confluence username.
+* **Confluence** - [Accumulo Confluence Space][confluence] provides a collaboration space for design documents. If you require write
+access, please [contact us][contact] with your Confluence username and request details.
 
 For more information, see the [contributor guide](/contributors-guide/).
 

--- a/pages/how-to-contribute.md
+++ b/pages/how-to-contribute.md
@@ -8,6 +8,7 @@ Contributions are welcome to all Apache Accumulo repositories. While most contri
 there are other ways to contribute to Accumulo:
 
 * communicate on one of the [mailing lists](/contact-us/#mailing-lists)
+* participate in design discussions on [Confluence](/contact-us/#Confluence)
 * review [pull requests](https://github.com/apache/accumulo/pulls)
 * verify and test new [releases](/release/)
 * update the [Accumulo website and documentation](https://github.com/apache/accumulo-website)

--- a/pages/how-to-contribute.md
+++ b/pages/how-to-contribute.md
@@ -8,7 +8,7 @@ Contributions are welcome to all Apache Accumulo repositories. While most contri
 there are other ways to contribute to Accumulo:
 
 * communicate on one of the [mailing lists](/contact-us/#mailing-lists)
-* participate in design discussions on [Confluence](/contact-us/#Confluence)
+* participate in design discussions on [Confluence](/#Confluence)
 * review [pull requests](https://github.com/apache/accumulo/pulls)
 * verify and test new [releases](/release/)
 * update the [Accumulo website and documentation](https://github.com/apache/accumulo-website)
@@ -30,6 +30,11 @@ Any questions/ideas don't hesitate to [contact us][contact].
 | [Wikisearch][s]    | [Contribute][sc] [Issues][si]  | Example application that indexes and queries Wikipedia data |
 | [Proxy][p]         | [Issues][pi]                   | Apache Thrift service that exposes Accumulo to other languages |
 | [Maven plugin][m]  | [Issues][mi]                   | Maven plugin that runs Accumulo |
+
+## Confluence
+
+The [Accumulo Confluence Space][confluence] provides a collaboration space for design documents.  If you would like write
+access, please send a request to `dev@accumulo.apache.org` with your Confluence username.
 
 ## Example Contribution workflow
 

--- a/pages/how-to-contribute.md
+++ b/pages/how-to-contribute.md
@@ -20,16 +20,16 @@ Any questions/ideas don't hesitate to [contact us][contact].
 
 ## Accumulo Repositories
 
-| Repository         | Links                          | Description
-| -------------------| ------------------------------ | -----------
-| [Accumulo][a]      | [Contribute][ac] [Issues][ai]  | Core Project
-| [Website][w]       | [Contribute][wc] [Issues][wi]  | Source for this website
-| [Examples][e]      | [Contribute][ec] [Issues][ei]  | Example code
-| [Testing][t]       | [Contribute][tc] [Issues][ti]  | Test suites such as continuous ingest and random walk
-| [Docker][d]        | [Contribute][dc] [Issues][di]  | Source for Accumulo Docker image
-| [Wikisearch][s]    | [Contribute][sc] [Issues][si]  | Example application that indexes and queries Wikipedia data
-| [Proxy][p]         | [Issues][pi]                   | Apache Thrift service that exposes Accumulo to other languages
-| [Maven plugin][m]  | [Issues][mi]                   | Maven plugin that runs Accumulo
+| Repository         | Links                          | Description |
+| -------------------| ------------------------------ | ----------- |
+| [Accumulo][a]      | [Contribute][ac] [Issues][ai]  | Core Project |
+| [Website][w]       | [Contribute][wc] [Issues][wi]  | Source for this website |
+| [Examples][e]      | [Contribute][ec] [Issues][ei]  | Example code |
+| [Testing][t]       | [Contribute][tc] [Issues][ti]  | Test suites such as continuous ingest and random walk |
+| [Docker][d]        | [Contribute][dc] [Issues][di]  | Source for Accumulo Docker image |
+| [Wikisearch][s]    | [Contribute][sc] [Issues][si]  | Example application that indexes and queries Wikipedia data |
+| [Proxy][p]         | [Issues][pi]                   | Apache Thrift service that exposes Accumulo to other languages |
+| [Maven plugin][m]  | [Issues][mi]                   | Maven plugin that runs Accumulo |
 
 ## Example Contribution workflow
 


### PR DESCRIPTION
Update the how to contribute page to include a link to the Accumulo Confluence Space