### PR TITLE
Improvements to 2.1.2 release notes

### DIFF
--- a/_posts/release/2023-08-14-accumulo-2.1.2.md
+++ b/_posts/release/2023-08-14-accumulo-2.1.2.md
@@ -11,7 +11,7 @@ bug fixes and minor enhancements. This version supersedes 2.1.1. Users
 upgrading to 2.1 should upgrade directly to this version instead of 2.1.1.
 
 Included here are some highlights of the most interesting bugs fixed and features
-added in 2.1.2. For the full set of bug fixes, please see the commit history
+added in 2.1.2. For the full set of changes, please see the commit history
 or issue tracker.
 
 NOTE: This 2.1 release also includes any applicable bug fixes and improvements
@@ -39,7 +39,8 @@ If the context name is null, an empty string, results in an exception creating t
 context, or if the resulting classloader is null, then an exception will be returned and the property
 will not be set.
 
-* {% ghi 3548 %}, {% ghi 3561 %} Displayed Manager state prominently on the Monitor UI.
+* {% ghi 3548 %}, {% ghi 3561 %} Added a banner to the manager page in the Monitor that displays the 
+manager state and goal state when they are not normal.
 
 * {% ghi 3383 %}, {% ghi 3680 %} Prompt the user for confirmation when they attempt to set a deprecated
 property in the Shell as a way to get them to use the non-deprecated property.
@@ -48,7 +49,7 @@ property in the Shell as a way to get them to use the non-deprecated property.
 Monitor UI.
 
 * {% ghi 3233 %}, {% ghi 3562 %} Added copy-properties option to createnamespace and createtable shell
-commands
+commands.
 
 ### Notable Bug Fixes
 
@@ -58,18 +59,20 @@ which failed the minor compaction thread. Once the minor compaction thread is de
 include catching a broader range of exceptions in the minor compaction thread in an attempt to save it
 from dying and initiating a minor compaction before closing the compactable object in the tablet.
   
-* {% ghi 3630 %}, {% ghi 3631 %} ClientContext incorrectly converting BatchWriter latency and timeout values
+* {% ghi 3630 %}, {% ghi 3631 %} A bug where ClientContext was incorrectly converting BatchWriter
+latency and timeout values was fixed.
 
 * {% ghi 3617 %}, {% ghi 3622 %} Close LocalityGroupReader when IOException is thrown to release reference
 to a possibly corrupted stream in a cached block file.
 
-* {% ghi 3570 %}, {% ghi 3571 %} Fix TabletGroupWatcher shutdown order
+* {% ghi 3570 %}, {% ghi 3571 %} Fixed the TabletGroupWatcher shutdown order.
 
-* {% ghi 3569 %}, {% ghi 3579 %} {% ghi 3644 %} Changes to ensure that scan sessions are cleaned up
+* {% ghi 3569 %}, {% ghi 3579 %} {% ghi 3644 %} Changes to ensure that scan sessions are cleaned up.
 
-* {% ghi 3553 %}, {% ghi 3555 %} A failed user compaction would not retry and would hang
+* {% ghi 3553 %}, {% ghi 3555 %} A bug where a failed user compaction would not retry and would hang
+was fixed.
 
-* {% ghi 3600 %} Normalized metric labels and structure
+* {% ghi 3600 %} Normalized metric labels and structure.
 
 ## Upgrading
 


### PR DESCRIPTION
This PR:
* changes the note about the manager page changes in the monitor
* makes sure all bullet points have a period at the end
* slightly adjusts some misc. wordage