### PR TITLE
Update fontawesome, jquery and datatables versions

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -52,13 +52,13 @@
         <li class="dropdown">
           <a class="dropdown-toggle" data-toggle="dropdown" href="#"><img alt="Apache Software Foundation" src="https://www.apache.org/foundation/press/kit/feather.svg" width="15"/><span class="caret"></span></a>
           <ul class="dropdown-menu">
-            <li><a href="https://www.apache.org">Apache Homepage <i class="fa fa-external-link"></i></a></li>
-            <li><a href="https://www.apache.org/licenses/">License <i class="fa fa-external-link"></i></a></li>
-            <li><a href="https://www.apache.org/foundation/sponsorship">Sponsorship <i class="fa fa-external-link"></i></a></li>
-            <li><a href="https://www.apache.org/security">Security <i class="fa fa-external-link"></i></a></li>
-            <li><a href="https://www.apache.org/foundation/thanks">Thanks <i class="fa fa-external-link"></i></a></li>
-            <li><a href="https://www.apache.org/foundation/policies/conduct">Code of Conduct <i class="fa fa-external-link"></i></a></li>
-            <li><a href="https://www.apache.org/events/current-event.html">Current Event <i class="fa fa-external-link"></i></a></li>
+            <li><a href="https://www.apache.org">Apache Homepage <i class="fa-solid fa-up-right-from-square"></i></a></li>
+            <li><a href="https://www.apache.org/licenses/">License <i class="fa-solid fa-up-right-from-square"></i></a></li>
+            <li><a href="https://www.apache.org/foundation/sponsorship">Sponsorship <i class="fa-solid fa-up-right-from-square"></i></a></li>
+            <li><a href="https://www.apache.org/security">Security <i class="fa-solid fa-up-right-from-square"></i></a></li>
+            <li><a href="https://www.apache.org/foundation/thanks">Thanks <i class="fa-solid fa-up-right-from-square"></i></a></li>
+            <li><a href="https://www.apache.org/foundation/policies/conduct">Code of Conduct <i class="fa-solid fa-up-right-from-square"></i></a></li>
+            <li><a href="https://www.apache.org/events/current-event.html">Current Event <i class="fa-solid fa-up-right-from-square"></i></a></li>
           </ul>
         </li>
       </ul>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -13,7 +13,7 @@
       var $el, icon, id;
       $el = $(el);
       id = $el.attr('id');
-      icon = '<i class="fa fa-link"></i>';
+      icon = '<i class="fa-solid fa-link"></i>';
       if (id) {
         return $el.append($("<a />").addClass("header-link").attr("href", "#" + id).html(icon));
       }

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,15 +21,15 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/paper/bootstrap.min.css" rel="stylesheet" integrity="sha384-awusxf8AUojygHf2+joICySzB780jVvQaVCAt1clU3QsyAitLGul28Qxb2r1e5g+" crossorigin="anonymous">
-<link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
-<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs/jq-2.2.3/dt-1.10.12/datatables.min.css">
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" rel="stylesheet">
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/dt-1.13.6/datatables.min.css">
 <link href="{{ site.baseurl }}/css/accumulo.css" rel="stylesheet" type="text/css">
 
 <title>{% if page.title_prefix %}{{ page.title_prefix | escape }}{% endif %}{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.0/jquery.min.js" integrity="sha256-2Pmvv0kuTBOenSvLm6bvfBSSHrUJ+3A7x6P5Ebd07/g=" crossorigin="anonymous"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-<script type="text/javascript" src="https://cdn.datatables.net/v/bs/jq-2.2.3/dt-1.10.12/datatables.min.js"></script>
+<script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.13.6/datatables.min.js"></script>
 <script type="text/javascript" src="https://www.apachecon.com/event-images/snippet.js"></script>
 {% include scripts.html %}
 </head>

--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@ skiph1fortitle: true
   <div class="col-md-8">
     <div class="jumbotron" style="text-align: center">
       <h3>Apache Accumulo&reg; is a sorted, distributed key/value store that provides robust, scalable data storage and retrieval.</h3>
-      <a style="margin-right: 20px" class="btn btn-success" href="downloads/" role="button"><i class="fa fa-download fa-lg"></i> Download</a>
-      <a class="btn btn-primary" href="https://github.com/apache/accumulo" role="button"><i class="fa fa-github fa-lg"></i> GitHub</a>
+      <a style="margin-right: 20px" class="btn btn-success" href="downloads/" role="button"><i class="fa-solid fa-download fa-lg"></i> Download</a>
+      <a class="btn btn-primary" href="https://github.com/apache/accumulo" role="button"><i class="fa-brands fa-github fa-lg"></i> GitHub</a>
     </div>
     <p id="home-description">With Apache Accumulo, users can store and manage large data sets across a cluster. Accumulo uses <a href="https://hadoop.apache.org">Apache Hadoop</a>'s HDFS to store its data and <a href="https://zookeeper.apache.org">Apache ZooKeeper</a> for consensus. While many users interact directly with Accumulo, several <a href="/related-projects">open source projects</a> use Accumulo as their underlying store.</p>
     <p id="home-description">To learn more about Accumulo, take the <a href="/tour">Accumulo tour</a>, read the <a href="{{ site.docs_baseurl }}">user manual</a> and run the Accumulo <a href="https://github.com/apache/accumulo-examples">example code</a>. Feel free to <a href="/contact-us">contact us</a> if you have any questions.


### PR DESCRIPTION
This PR:
* bumps fontawesome from 4.0.3 -> 6.4.2
  * this required some changes to the class names of the icons
  * [details on the fontawesome site](https://fontawesome.com/docs/web/setup/upgrade/upgrade-from-v4#what-s-changed-from-version-4-to-6) outlining what has changed between these versions
  * the only visual change that took place was the link icon from https://fontawesome.com/v4/icon/link to https://fontawesome.com/icons/link?f=classic&s=solid
  * In the user manuals from 1.x versions, the html generated by asciidoc has a few places that font awesome is used and it looks like the old version but i am not sure where that code is generated or if we want to change that.
* bumps datatables from 1.10.12 to 1.13.6
  * the 1.10.12 import included a version of jquery with the download but I saw a note [on the downloads page](https://datatables.net/download/index) in the select packages section, that says "DataTables requires jQuery. Don't select either version if you already have it.". Because of this, the new link to datatables download does not include a version of jquery with it
* bumps jquery from 2.2.4 to 3.7.0

This partially addresses #394. Everything but the bootstrap update is handled here in this PR.