### PR TITLE
Use bootstrap styling for dataTables

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,14 +22,14 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/paper/bootstrap.min.css" rel="stylesheet" integrity="sha384-awusxf8AUojygHf2+joICySzB780jVvQaVCAt1clU3QsyAitLGul28Qxb2r1e5g+" crossorigin="anonymous">
 <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" rel="stylesheet">
-<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/dt-1.13.6/datatables.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs/dt-1.13.6/datatables.min.css">
 <link href="{{ site.baseurl }}/css/accumulo.css" rel="stylesheet" type="text/css">
 
 <title>{% if page.title_prefix %}{{ page.title_prefix | escape }}{% endif %}{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.0/jquery.min.js" integrity="sha256-2Pmvv0kuTBOenSvLm6bvfBSSHrUJ+3A7x6P5Ebd07/g=" crossorigin="anonymous"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-<script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.13.6/datatables.min.js"></script>
+<script type="text/javascript" src="https://cdn.datatables.net/v/bs/dt-1.13.6/datatables.min.js"></script>
 <script type="text/javascript" src="https://www.apachecon.com/event-images/snippet.js"></script>
 {% include scripts.html %}
 </head>


### PR DESCRIPTION
* Use Bootstrap 3 instead of dataTables default styling, so the tables can fit the rest of the site's theme by default
* This will need to be switched to Bootstrap 5 versions when Bootstrap is updated

Follow up from #396 