### PR TITLE
Fix code block languages

### DIFF
--- a/_docs-2/administration/multivolume.md
+++ b/_docs-2/administration/multivolume.md
@@ -48,7 +48,7 @@ in its metadata.  The example configuration below will replace ns1 with nsA and
 ns2 with nsB in Accumulo metadata. For this property to take affect, Accumulo will
 need to be restarted.
 
-```xml
+```
 instance.volumes.replacements=hdfs://ns1:9001 hdfs://nsA:9001, hdfs://ns2:9001 hdfs://nsB:9001
 ```
 

--- a/_docs-2/administration/replication.md
+++ b/_docs-2/administration/replication.md
@@ -73,7 +73,7 @@ To configure a peer with the name `peer1` which is an Accumulo system with an in
 and a ZooKeeper quorum of `10.0.0.1,10.0.2.1,10.0.3.1`, invoke the following
 command in the shell.
 
-```
+```console
 root@accumulo_primary> config -s
 replication.peer.peer1=org.apache.accumulo.tserver.replication.AccumuloReplicaSystem,accumulo_peer,10.0.0.1,10.0.2.1,10.0.3.1
 ```
@@ -83,7 +83,7 @@ to use when authenticating with this peer. On our peer, we make a special user
 which has permission to write to the tables we want to replicate data into, "replication"
 with a password of "password". We then need to record this in the primary's configuration.
 
-```
+```console
 root@accumulo_primary> config -s replication.peer.user.peer1=replication
 root@accumulo_primary> config -s replication.peer.password.peer1=password
 ```
@@ -93,7 +93,7 @@ file per peer can be configured instead of a password. The provided keytabs must
 by the unix user running Accumulo. They keytab for a peer can be unique from the
 keytab used by Accumulo or any keytabs for other peers.
 
-```
+```console
 accumulo@EXAMPLE.COM@accumulo_primary> config -s replication.peer.user.peer1=replication@EXAMPLE.COM
 accumulo@EXAMPLE.COM@accumulo_primary> config -s replication.peer.keytab.peer1=/path/to/replication.keytab
 ```
@@ -107,7 +107,7 @@ cluster, this is a table ID. In this example, we want to enable replication on
 `my_table` and configure our peer `accumulo_peer` as a target, sending
 the data to the table with an ID of `2` in `accumulo_peer`.
 
-```
+```console
 root@accumulo_primary> config -t my_table -s table.replication=true
 root@accumulo_primary> config -t my_table -s table.replication.target.accumulo_peer=2
 ```
@@ -225,7 +225,7 @@ The rest of the configuration is dynamic and is best configured on the fly (in Z
 The next series of command are to be run on the peer system. Create a user account for the primary instance called
 "peer". The password for this account will need to be saved in the configuration on the primary
 
-```
+```console
 root@peer> createtable my_table
 root@peer> createuser peer
 root@peer> grant -t my_table -u peer Table.WRITE
@@ -241,7 +241,7 @@ Next, configure the primary instance.
 
 #### Set up the table
 
-```
+```console
 root@primary> createtable my_table
 ```
 
@@ -252,7 +252,7 @@ that we want to use, and the configuration for the [AccumuloReplicaSystem]. In t
 Instance name for `peer` and the ZooKeeper quorum string. The configuration key is of the form
 `replication.peer.$peer_name`.
 
-```
+```console
 root@primary> config -s replication.peer.peer=org.apache.accumulo.tserver.replication.AccumuloReplicaSystem,peer,$peer_zk_quorum
 ```
 
@@ -261,7 +261,7 @@ root@primary> config -s replication.peer.peer=org.apache.accumulo.tserver.replic
 We want to use that special username and password that we created on the peer, so we have a means to write data to
 the table that we want to replicate to. The configuration key is of the form "replication.peer.user.$peer_name".
 
-```
+```console
 root@primary> config -s replication.peer.user.peer=peer
 root@primary> config -s replication.peer.password.peer=peer
 ```
@@ -276,13 +276,13 @@ The configuration for the AccumuloReplicaSystem is the table ID for the table on
 want to replicate into. Be sure to use the correct value for $peer_table_id. The configuration key is of
 the form "table.replication.target.$peer_name".
 
-```
+```console
 root@primary> config -t my_table -s table.replication.target.peer=$peer_table_id
 ```
 
 Finally, we can enable replication on this table.
 
-```
+```console
 root@primary> config -t my_table -s table.replication=true
 ```
 

--- a/_docs-2/configuration/overview.md
+++ b/_docs-2/configuration/overview.md
@@ -136,7 +136,7 @@ Accumulo's current configuration can be viewed in the shell using the `config` c
 Below is an example shell output from viewing configuration for the table `foo`. Please note how `table.compaction.major.ratio`
 is set in multiple locations, but the value `1.6` set in the `table` scope is used because it has the highest precedence.
 
-```
+```console
 root@accumulo-instance> config -t foo
 ---------+---------------------------------------------+-----------------------
 SCOPE    | NAME                                        | VALUE

--- a/_docs-2/development/summaries.md
+++ b/_docs-2/development/summaries.md
@@ -71,80 +71,82 @@ class has options for creating RFiles with embedded summary data.
 
 This example walks through using summarizers in the Accumulo shell.  Below, a
 table is created and some data is inserted to summarize.
-
-    root@uno> createtable summary_test
-    root@uno summary_test> setauths -u root -s PI,GEO,TIME
-    root@uno summary_test> insert 3b503bd name last Doe
-    root@uno summary_test> insert 3b503bd name first John
-    root@uno summary_test> insert 3b503bd contact address "123 Park Ave, NY, NY" -l PI&GEO
-    root@uno summary_test> insert 3b503bd date birth "1/11/1942" -l PI&TIME
-    root@uno summary_test> insert 3b503bd date married "5/11/1962" -l PI&TIME
-    root@uno summary_test> insert 3b503bd contact home_phone 1-123-456-7890 -l PI
-    root@uno summary_test> insert d5d18dd contact address "50 Lake Shore Dr, Chicago, IL" -l PI&GEO
-    root@uno summary_test> insert d5d18dd name first Jane
-    root@uno summary_test> insert d5d18dd name last Doe
-    root@uno summary_test> insert d5d18dd date birth 8/15/1969 -l PI&TIME
-    root@uno summary_test> scan -s PI,GEO,TIME
-    3b503bd contact:address [PI&GEO]    123 Park Ave, NY, NY
-    3b503bd contact:home_phone [PI]    1-123-456-7890
-    3b503bd date:birth [PI&TIME]    1/11/1942
-    3b503bd date:married [PI&TIME]    5/11/1962
-    3b503bd name:first []    John
-    3b503bd name:last []    Doe
-    d5d18dd contact:address [PI&GEO]    50 Lake Shore Dr, Chicago, IL
-    d5d18dd date:birth [PI&TIME]    8/15/1969
-    d5d18dd name:first []    Jane
-    d5d18dd name:last []    Doe
+```console
+root@uno> createtable summary_test
+root@uno summary_test> setauths -u root -s PI,GEO,TIME
+root@uno summary_test> insert 3b503bd name last Doe
+root@uno summary_test> insert 3b503bd name first John
+root@uno summary_test> insert 3b503bd contact address "123 Park Ave, NY, NY" -l PI&GEO
+root@uno summary_test> insert 3b503bd date birth "1/11/1942" -l PI&TIME
+root@uno summary_test> insert 3b503bd date married "5/11/1962" -l PI&TIME
+root@uno summary_test> insert 3b503bd contact home_phone 1-123-456-7890 -l PI
+root@uno summary_test> insert d5d18dd contact address "50 Lake Shore Dr, Chicago, IL" -l PI&GEO
+root@uno summary_test> insert d5d18dd name first Jane
+root@uno summary_test> insert d5d18dd name last Doe
+root@uno summary_test> insert d5d18dd date birth 8/15/1969 -l PI&TIME
+root@uno summary_test> scan -s PI,GEO,TIME
+3b503bd contact:address [PI&GEO]    123 Park Ave, NY, NY
+3b503bd contact:home_phone [PI]    1-123-456-7890
+3b503bd date:birth [PI&TIME]    1/11/1942
+3b503bd date:married [PI&TIME]    5/11/1962
+3b503bd name:first []    John
+3b503bd name:last []    Doe
+d5d18dd contact:address [PI&GEO]    50 Lake Shore Dr, Chicago, IL
+d5d18dd date:birth [PI&TIME]    8/15/1969
+d5d18dd name:first []    Jane
+d5d18dd name:last []    Doe
+```
 
 After inserting the data, summaries are requested below.  No summaries are returned.
-
-    root@uno summary_test> summaries
+```console
+root@uno summary_test> summaries
+```
 
 The visibility summarizer is configured below and the table is flushed.
 Flushing the table creates a file creating summary data in the process. The
 summary data returned counts how many times each column visibility occurred.
 The statistics with a `c:` prefix are visibilities.  The others are generic
 statistics created by the CountingSummarizer that VisibilitySummarizer extends.
-
-    root@uno summary_test> config -t summary_test -s table.summarizer.vis=org.apache.accumulo.core.client.summary.summarizers.VisibilitySummarizer
-    root@uno summary_test> summaries
-    root@uno summary_test> flush -w
-    2017-02-24 19:54:46,090 [shell.Shell] INFO : Flush of table summary_test completed.
-    root@uno summary_test> summaries
-    Summarizer         : org.apache.accumulo.core.client.summary.summarizers.VisibilitySummarizer vis {}
-    File Statistics    : [total:1, missing:0, extra:0, large:0]
-    Summary Statistics :
-       c:                                                           = 4
-       c:PI                                                         = 1
-       c:PI&GEO                                                     = 2
-       c:PI&TIME                                                    = 3
-       emitted                                                      = 10
-       seen                                                         = 10
-       tooLong                                                      = 0
-       tooMany                                                      = 0
-
+```console
+root@uno summary_test> config -t summary_test -s table.summarizer.vis=org.apache.accumulo.core.client.summary.summarizers.VisibilitySummarizer
+root@uno summary_test> summaries
+root@uno summary_test> flush -w
+2017-02-24 19:54:46,090 [shell.Shell] INFO : Flush of table summary_test completed.
+root@uno summary_test> summaries
+Summarizer         : org.apache.accumulo.core.client.summary.summarizers.VisibilitySummarizer vis {}
+File Statistics    : [total:1, missing:0, extra:0, large:0]
+Summary Statistics :
+   c:                                                           = 4
+   c:PI                                                         = 1
+   c:PI&GEO                                                     = 2
+   c:PI&TIME                                                    = 3
+   emitted                                                      = 10
+   seen                                                         = 10
+   tooLong                                                      = 0
+   tooMany                                                      = 0
+```
 VisibilitySummarizer has an option `maxCounters` that determines the max number
 of column visibilities it will track.  Below this option is set and compaction
 is forced to regenerate summary data.  The new summary data only has three
 visibilities and now the `tooMany` statistic is 4.  This is the number of
 visibilities that were not counted.
 
-```
- root@uno summary_test> config -t summary_test -s table.summarizer.vis.opt.maxCounters=3
- root@uno summary_test> compact -w
- 2017-02-24 19:54:46,267 [shell.Shell] INFO : Compacting table ...
- 2017-02-24 19:54:47,127 [shell.Shell] INFO : Compaction of table summary_test completed for given range
- root@uno summary_test> summaries
-  Summarizer         : org.apache.accumulo.core.client.summary.summarizers.VisibilitySummarizer vis {maxCounters=3}
-  File Statistics    : [total:1, missing:0, extra:0, large:0]
-  Summary Statistics :
-     c:PI                                                         = 1
-     c:PI&GEO                                                     = 2
-     c:PI&TIME                                                    = 3
-     emitted                                                      = 10
-     seen                                                         = 10
-     tooLong                                                      = 0
-     tooMany                                                      = 4
+```console
+root@uno summary_test> config -t summary_test -s table.summarizer.vis.opt.maxCounters=3
+root@uno summary_test> compact -w
+2017-02-24 19:54:46,267 [shell.Shell] INFO : Compacting table ...
+2017-02-24 19:54:47,127 [shell.Shell] INFO : Compaction of table summary_test completed for given range
+root@uno summary_test> summaries
+   Summarizer         : org.apache.accumulo.core.client.summary.summarizers.VisibilitySummarizer vis {maxCounters=3}
+   File Statistics    : [total:1, missing:0, extra:0, large:0]
+   Summary Statistics :
+      c:PI                                                         = 1
+      c:PI&GEO                                                     = 2
+      c:PI&TIME                                                    = 3
+      emitted                                                      = 10
+      seen                                                         = 10
+      tooLong                                                      = 0
+      tooMany                                                      = 4
 ```
 
 Another summarizer is configured below that tracks the number of deletes.  Also,
@@ -155,7 +157,7 @@ configurable.  Below a delete is added and it's reflected in the statistics.  In
 this case there is 1 delete and 10 non-deletes, not enough to force a
 compaction of the tablet.
 
-```
+```console
 root@uno summary_test> config -t summary_test -s table.summarizer.del=org.apache.accumulo.core.client.summary.summarizers.DeletesSummarizer
 root@uno summary_test> compact -w
 2017-02-24 19:54:47,282 [shell.Shell] INFO : Compacting table ...
@@ -191,7 +193,7 @@ compaction of all files is the only time when delete markers are dropped.  The
 compaction ratio was set to 10 above to show that the number of files did not
 trigger the compaction.   After the compaction there no deletes 6 non-deletes.
 
-```
+```console
 root@uno summary_test> deletemany -r d5d18dd -f
 [DELETED] d5d18dd contact:address [PI&GEO]
 [DELETED] d5d18dd name:first []

--- a/_docs-2/getting-started/clients.md
+++ b/_docs-2/getting-started/clients.md
@@ -71,7 +71,7 @@ If an [accumulo-client.properties] file or a Java Properties object is used to c
 
 If a token class is used for `auth.type`, you can create a Base64 encoded token using the `accumulo create-token` command.
 
-```
+```console
 $ accumulo create-token
 Username (aka principal): root
 the password for the principal: ******
@@ -187,11 +187,11 @@ These levels are:
 Durability can be set in multiple ways:
 
 1. The default durability of all tables can be set using [table.durability].
-    ```
+    ```console
     root@uno> config -s table.durability=flush
     ```
 2. The default durability of a table can be overriden by setting [table.durability] for that table.
-    ```
+    ```console
     root@uno> config -t mytable -s table.durability=sync
     ```
 3. When creating an [AccumuloClient], the default durability can be overridden using `withBatchWriterConfig()`

--- a/_docs-2/getting-started/shell.md
+++ b/_docs-2/getting-started/shell.md
@@ -28,34 +28,38 @@ and then display the following prompt:
 ## Basic Administration
 
 The `tables` command will list all existing tables.
-
-    root@myinstance> tables
-    accumulo.metadata
-    accumulo.root
+```console
+root@myinstance> tables
+accumulo.metadata
+accumulo.root
+```
 
 The `createtable` command creates a new table.
-
-    root@myinstance> createtable mytable
-    root@myinstance mytable> tables
-    accumulo.metadata
-    accumulo.root
-    mytable
+```console
+root@myinstance> createtable mytable
+root@myinstance mytable> tables
+accumulo.metadata
+accumulo.root
+mytable
+```
 
 The `deletetable` command deletes a table.
-
-    root@myinstance testtable> deletetable testtable
-    deletetable { testtable } (yes|no)? yes
-    Table: [testtable] has been deleted.
+```console
+root@myinstance testtable> deletetable testtable
+deletetable { testtable } (yes|no)? yes
+Table: [testtable] has been deleted.
+```
 
 The shell can be used to insert updates and scan tables. This is useful for inspecting tables.
+```console
+root@myinstance mytable> scan
 
-    root@myinstance mytable> scan
+root@myinstance mytable> insert row1 colf colq value1
+insert successful
 
-    root@myinstance mytable> insert row1 colf colq value1
-    insert successful
-
-    root@myinstance mytable> scan
-    row1 colf:colq [] value1
+root@myinstance mytable> scan
+row1 colf:colq [] value1
+```
 
 The value in brackets `[]` would be the visibility labels. Since none were used, this is empty for this row.
 You can use the `-st` option to scan to see the timestamp for the cell, too.
@@ -64,24 +68,25 @@ You can use the `-st` option to scan to see the timestamp for the cell, too.
 
 The `compact` command instructs Accumulo to schedule a compaction of the table during which
 files are consolidated and deleted entries are removed.
-
-    root@myinstance mytable> compact -t mytable
-    07 16:13:53,201 [shell.Shell] INFO : Compaction of table mytable started for given range
+```console
+root@myinstance mytable> compact -t mytable
+07 16:13:53,201 [shell.Shell] INFO : Compaction of table mytable started for given range
+```
 
 If needed, the compaction can be canceled using `compact --cancel -t mytable`.
 
 The `flush` command instructs Accumulo to write all entries currently in memory for a given table
 to disk.
-
-    root@myinstance mytable> flush -t mytable
-    07 16:14:19,351 [shell.Shell] INFO : Flush of table mytable
-    initiated...
+```console
+root@myinstance mytable> flush -t mytable
+07 16:14:19,351 [shell.Shell] INFO : Flush of table mytable initiated...
+```
 
 ## User Administration
 
 The Shell can be used to add, remove, and grant privileges to users.
 
-```
+```console
 root@myinstance mytable> createuser bob
 Enter new password for 'bob': *********
 Please confirm new password for 'bob': *********

--- a/_docs-2/getting-started/table_configuration.md
+++ b/_docs-2/getting-started/table_configuration.md
@@ -70,7 +70,7 @@ client.
 
 Constraints can be enabled by setting a table property as follows:
 
-```
+```console
 user@myinstance mytable> constraint -t mytable -a com.test.ExampleConstraint com.test.AnotherConstraint
 
 user@myinstance mytable> constraint -l
@@ -183,7 +183,7 @@ given date. The default is to return the one most recent version.
 The version policy can be changed by changing the VersioningIterator options for a
 table as follows:
 
-```
+```console
 user@myinstance mytable> config -t mytable -s table.iterator.scan.vers.opt.maxVersions=3
 
 user@myinstance mytable> config -t mytable -s table.iterator.minc.vers.opt.maxVersions=3
@@ -234,7 +234,7 @@ The AgeOff filter can be configured to remove data older than a certain date or 
 amount of time from the present. The following example sets a table to delete
 everything inserted over 30 seconds ago:
 
-```
+```console
 user@myinstance> createtable filtertest
 
 user@myinstance filtertest> setiter -t filtertest -scan -minc -majc -p 10 -n myfilter -ageoff
@@ -307,7 +307,7 @@ The table would reflect only one aggregate value:
 
 Combiners can be enabled for a table using the setiter command in the shell. Below is an example.
 
-```
+```console
 root@a14 perDayCounts> setiter -t perDayCounts -p 10 -scan -minc -majc -n daycount
                        -class org.apache.accumulo.core.iterators.user.SummingCombiner
 TypedValueCombiner can interpret Values as a variety of number encodings
@@ -455,7 +455,7 @@ created, only the user that created the clone can read and write to it.
 In the following example we see that data inserted after the clone operation is
 not visible in the clone.
 
-```
+```console
 root@a14> createtable people
 
 root@a14 people> insert 890435 name last Doe
@@ -489,7 +489,7 @@ inserted into cic and its flushed, du shows the two tables still share 428M but
 cic has 226 bytes to itself. Finally, table cic is compacted and then du shows
 that each table uses 428M.
 
-```
+```console
 root@a14> du ci
              428,482,573 [ci]
 

--- a/_docs-2/security/authentication.md
+++ b/_docs-2/security/authentication.md
@@ -26,7 +26,7 @@ a password.  This `root` user is used to create other users.
 
 Users can be created in the shell:
 
-```
+```console
 root@uno> createuser bob
 Enter new password for 'bob': ****
 Please confirm new password for 'bob': ****
@@ -45,7 +45,7 @@ or when they log in to the [Accumulo shell]({% durl getting-started/shell %}).
 
 Authentication can also be tested in the shell:
 
-```
+```console
 root@myinstance mytable> authenticate bob
 Enter current password for 'bob': ****
 Valid
@@ -61,7 +61,7 @@ boolean valid = client.securityOperations().authenticateUser("bob", new Password
 
 A user's password can be changed in the shell:
 
-```
+```console
 root@uno> passwd -u bob
 Enter current password for 'root': ******
 Enter new password for 'bob': ***
@@ -77,7 +77,7 @@ client.securityOperations().changeLocalUserPassword("bob", new PasswordToken("pa
 
 Users can be removed in the shell:
 
-```
+```console
 root@uno> dropuser bob
 dropuser { bob } (yes|no)? yes
 ```

--- a/_docs-2/security/kerberos.md
+++ b/_docs-2/security/kerberos.md
@@ -208,7 +208,7 @@ existing users in the system; you will need to reassign user permissions based o
 prompted for a password you can just hit return, since it won't be used.
 3. Start the Accumulo cluster
 
-```
+```console
 $ accumulo-cluster stop
 ...
 $ accumulo init --reset-security
@@ -289,7 +289,7 @@ users with the system permission are allowed to obtain delegation tokens. It is 
 to configure confidentiality with SASL, using the `rpc.sasl.qop=auth-conf` configuration property, to
 ensure that prying eyes cannot view the `DelegationToken` as it passes over the network.
 
-```
+```console
 # Check a user's permissions
 admin@REALM@accumulo> userpermissions -u user@REALM
 
@@ -316,7 +316,7 @@ to authenticate with Accumulo, access HDFS, etc.
 
 The user can verify the state of their local credentials cache by using the command `klist`.
 
-```shell
+```console
 $ klist
 Ticket cache: FILE:/tmp/krb5cc_123
 Default principal: user@EXAMPLE.COM
@@ -349,7 +349,7 @@ interact with the system.
 While this example logs in via `kinit` with a password, any login method that caches Kerberos tickets
 should work.
 
-```shell
+```console
 $ kinit accumulo_admin@EXAMPLE.COM
 Password for accumulo_admin@EXAMPLE.COM: ******************************
 $ accumulo shell

--- a/_docs-2/security/permissions.md
+++ b/_docs-2/security/permissions.md
@@ -24,7 +24,7 @@ The default permission handler is described below.
 
 Users can be granted permissions in the shell:
 
-```
+```console
 root@uno> grant System.CREATE_TABLE -s -u bob
 ```
 
@@ -38,7 +38,7 @@ client.securityOperations().grantSystem("bob", SystemPermission.CREATE_TABLE);
 
 Permissions can be listed for a user in the shell:
 
-```
+```console
 root@uno> userpermissions -u bob
 System permissions: System.CREATE_TABLE, System.DROP_TABLE
 
@@ -53,7 +53,7 @@ Table permissions (accumulo.root): Table.READ
 
 Permissions can be revoked for a user in the shell
 
-```
+```console
 root@uno> revoke System.CREATE_TABLE -s -u bob
 ```
 

--- a/pages/api.md
+++ b/pages/api.md
@@ -31,14 +31,14 @@ imports in a project using Accumulo.
 
 For 1.x:
 
-```regex
+```
 import\s+org\.apache\.accumulo\.(.*\.(impl|thrift|crypto)\..*|(?!(core\.(client|data|security)|minicluster)\.).*)
 ```
 
 For 2.0 and later, this can be simplified, because sub-packages not intended
 for public API were relocated, and also altered to include the new MapReduce module:
 
-```regex
+```
 import\s+org\.apache\.accumulo\.(?!(core\.(client|data|iterators|security)|minicluster|hadoop)\.).*
 ```
 

--- a/tour/authorizations-code.md
+++ b/tour/authorizations-code.md
@@ -7,17 +7,17 @@ Below is the solution for the previous Authorization exercise.
 For this example, it is best to start with a clean slate. So, if the "GothamPD" table currently
 exists, let's delete and begin fresh.
 
-```commandline
-client.tableOperations().delete("GothamPD");
-client.securityOperations().dropLocalUser("commissioner");
+```
+jshell> client.tableOperations().delete("GothamPD");
+jshell> client.securityOperations().dropLocalUser("commissioner");
 ```
 
 Create a table called "GothamPD".
-```commandline
+```
 jshell> client.tableOperations().create("GothamPD");
 ```
 Create a "secretId" authorization & visibility
-```commandline
+```
 jshell> String secretId = "secretId";
 secretId ==> "secretId"
 jshell> Authorizations auths = new Authorizations(secretId);
@@ -27,14 +27,14 @@ colVis ==> [secretId]
 ```
 
 Create a user with the "secretId" authorization and grant the commissioner read permissions on our table
-```commandline
+```
 jshell> client.securityOperations().createLocalUser("commissioner", new PasswordToken("gordonrocks"));
 jshell> client.securityOperations().changeUserAuthorizations("commissioner", auths);
 jshell> client.securityOperations().grantTablePermission("commissioner", "GothamPD", TablePermission.READ);
 ```
 
 Create three Mutation objects, securing the proper columns.
-```commandline
+```
 jshell> Mutation mutation1 = new Mutation("id0001");
 mutation1 ==> org.apache.accumulo.core.data.Mutation@1
 jshell> mutation1.put("hero", "alias", "Batman");
@@ -57,7 +57,7 @@ jshell> mutation3.put("villain", "wearsCape?", "false");
 Create a BatchWriter to the GothamPD table and add your mutations to it.
 Once the BatchWriter is closed the data will be available to scans.
 
-```commandline
+```
 jshell> try (BatchWriter writer = client.createBatchWriter("GothamPD")) {
     ...>   writer.addMutation(mutation1);
     ...>   writer.addMutation(mutation2);
@@ -67,7 +67,7 @@ jshell> try (BatchWriter writer = client.createBatchWriter("GothamPD")) {
 
 Now let's scan.
 
-```commandline
+```
 jshell> try (ScannerBase scan = client.createScanner("GothamPD", Authorizations.EMPTY)) {
    ...>   System.out.println("Gotham Police Department Persons of Interest:");
    ...>     for (Map.Entry<Key, Value> entry : scan) {
@@ -89,7 +89,7 @@ with the `secretId` authorization.
 
 Let's add the `auths` authorization to the default root user and scan again.
 
-```commandline
+```
  jshell> try (ScannerBase scan = client.createScanner("GothamPD", auths)) {
    ...>    System.out.println("Gotham Police Department Persons of Interest:");
    ...>      for (Map.Entry<Key, Value> entry : scan)
@@ -122,7 +122,7 @@ This results in an error since the root user doesn't have the authorizations we 
 Now, create a second client for the commissioner user and output all the rows visible to them.
 Make sure to pass the proper authorizations.
 
-```commandline
+```
 jshell> try (AccumuloClient commishClient = Accumulo.newClient().from(client.properties()).as("commissioner", "gordonrocks").build()) {
    ...>   try (ScannerBase scan = commishClient.createScanner("GothamPD", auths)) {
    ...>     System.out.println("Gotham Police Department Persons of Interest:");
@@ -135,7 +135,7 @@ jshell> try (AccumuloClient commishClient = Accumulo.newClient().from(client.pro
 
 The solution above will print (timestamp will differ):
 
-```commandline
+```
 Gotham Police Department Persons of Interest:
 Key : id0001 hero:alias [] 1654106385737 false            Value : Batman
 Key : id0001 hero:name [secretId] 1654106385737 false     Value : Bruce Wayne

--- a/tour/authorizations.md
+++ b/tour/authorizations.md
@@ -19,7 +19,7 @@ the proper authorizations can read their names.
 
 Create a "secretId" authorization & visibility.
 
-```commandline
+```
 jshell> String secretId = "secretId";
 secretId ==> "secretId"
 
@@ -32,7 +32,7 @@ colVis ==> [secretId]
 
 Create a user with the "secretId" authorization and grant read permissions on our table.
 
-```commandline
+```
 jshell> client.securityOperations().createLocalUser("commissioner", new PasswordToken("gordonrocks"));
 jshell> client.securityOperations().changeUserAuthorizations("commissioner", auths);
 jshell> client.securityOperations().grantTablePermission("commissioner", "GothamPD", TablePermission.READ);

--- a/tour/basic-read-write.md
+++ b/tour/basic-read-write.md
@@ -11,20 +11,20 @@ Our next exercise shows how to write and read from a table.
 Let's create a table called "GothamPD".
 
 At the JShell prompt, enter the following:
-```commandline
+```
 jshell> client.tableOperations().create("GothamPD");
 ```
 
 Accumulo uses Mutation objects to hold all changes to a row in a table. Each row has a unique row
 ID.
 
-```commandline
+```
 jshell> Mutation mutation1 = new Mutation("id0001");
 mutation1 ==> org.apache.accumulo.core.data.Mutation@1
 ```
 
 Create key/value pairs for Batman.  Put them in the "hero" family.
-```commandline
+```
 jshell> mutation1.put("hero","alias", "Batman");
 jshell> mutation1.put("hero","name", "Bruce Wayne");
 jshell> mutation1.put("hero","wearsCape?", "true");
@@ -33,7 +33,7 @@ jshell> mutation1.put("hero","wearsCape?", "true");
 Create a BatchWriter to the GothamPD table and add your mutation to it. Try-with-resources will
 close for us.
 
-```commandline
+```
 jshell> try (BatchWriter writer = client.createBatchWriter("GothamPD")) {
   ...>    writer.addMutation(mutation1);
   ...>  }
@@ -46,7 +46,7 @@ be resolved by either using the fully qualified name for the Scanner, or more ea
 base class, ```ScannerBase```, in place of ```Scanner``` (this should generally only be required when
 within the JShell environment).
 
-```commandline
+```
 jshell> try (ScannerBase scan = client.createScanner("GothamPD", Authorizations.EMPTY)) {
    ...>   System.out.println("Gotham Police Department Persons of Interest:");
    ...>   for(Map.Entry<Key, Value> entry : scan) {

--- a/tour/batch-scanner-code.md
+++ b/tour/batch-scanner-code.md
@@ -6,13 +6,13 @@ Below is a solution to the exercise.
 
 Create a table called "GothamBatch".
 
-```commandline
+```
 jshell> client.tableOperations().create("GothamBatch");
 ```
 
 Generate 10,000 rows of villain data
 
-```commandline
+```
 jshell> try (BatchWriter writer = client.createBatchWriter("GothamBatch")) {
    ...>   for (int i = 0; i < 10_000; i++) {
    ...>     Mutation m = new Mutation(String.format("id%04d", i));
@@ -25,7 +25,7 @@ jshell> try (BatchWriter writer = client.createBatchWriter("GothamBatch")) {
 ```
 
 Create a BatchScanner with 5 query threads
-```commandline
+```
 jshell> try (BatchScanner batchScanner = client.createBatchScanner("GothamBatch", Authorizations.EMPTY, 5)) {
    ...>
    ...>   // Create a collection of 2 sample ranges and set it to the batchScanner

--- a/tour/batch-scanner.md
+++ b/tour/batch-scanner.md
@@ -9,7 +9,7 @@ sorted order. A [BatchScanner] will retrieve multiple `Range`s of data using mul
 For this exercise, we need to generate a bunch of data to test BatchScanner.  Execute the code below
 to create our data set.
 
-```commandline
+```
 jshell> try (BatchWriter writer = client.createBatchWriter("GothamPD")) {
    ...>   for (int i = 0; i < 10_000; i++) {
    ...>     Mutation m = new Mutation(String.format("id%04d", i));

--- a/tour/client.md
+++ b/tour/client.md
@@ -15,7 +15,7 @@ For the tour, you will use the ```client``` provided by the JShell to perform th
 The properties used to create the client can be viewed in the file contained in the `clientPropUrl`
 variable.
 
-```commandline
+```
 jshell> /vars
 |    URL clientPropUrl = file:<path_to_accumulo-client.properties file>
 ```
@@ -23,7 +23,7 @@ jshell> /vars
 Let's start by using table operations to list the default tables and instance operations to get
 the instance ID.
 
-```commandline
+```
 jshell> client.tableOperations().list().forEach(System.out::println);
 accumulo.metadata
 accumulo.replication
@@ -32,7 +32,7 @@ accumulo.root
 
 Now let's retrieve the instance ID.
 
-```commandline
+```
 jshell> System.out.println(client.instanceOperations().getInstanceID());
 8b9839f7-cdc6-44ca-b527-43db45acc79f
 ```

--- a/tour/conditional-writer-code.md
+++ b/tour/conditional-writer-code.md
@@ -4,7 +4,7 @@ title: Conditional Writer Code
 
 Below is a solution to the exercise.
 
-```commandline
+```
 jshell> boolean setAddress(AccumuloClient client, String id, String expectedAddr, String newAddr) {
    ...>   try (ConditionalWriter writer = client.createConditionalWriter("GothamPD", new ConditionalWriterConfig())) {
    ...>     Condition condition = new Condition("location", "home");
@@ -24,7 +24,7 @@ The following output shows running the example with a conditional writer.
 Threads retry when conditional mutations are rejected.  The final address has
 all three modifications.
 
-```commandline
+```
 jshell> concurrent_writes()
 GothamPD table already exists...proceeding...
 Thread  52 attempting change '   1007 Mountain Dr, Gotham, New York  ' -> '1007 Mountain Dr, Gotham, New York'

--- a/tour/conditional-writer.md
+++ b/tour/conditional-writer.md
@@ -36,7 +36,7 @@ always makes the update, even when the value has changed since it was read.
 
 To simplify, we will create several small methods to illustrate the issue.
 
-```commandline
+```
 jshell> String getAddress(AccumuloClient client, String id)  {
     ...>   try (org.apache.accumulo.core.client.Scanner scan = new IsolatedScanner(client.createScanner("GothamPD", Authorizations.EMPTY))) {
     ...>     scan.setRange(Range.exact(id, "location", "home"));
@@ -102,7 +102,7 @@ The following is one of a few possible outputs.  Notice that only the
 modification of `Drive` to `Dr` shows up in the final output.  The other
 modifications were lost.
 
-```commandline
+```
 jshell> concurrent_writes()
 GothamPD table already exists...proceeding...
 Thread  52 attempting change '   1007 Mountain Drive, Gotham, New York  ' -> '   1007 Mountain Drive, Gotham, NY  '

--- a/tour/data-model-code.md
+++ b/tour/data-model-code.md
@@ -4,11 +4,11 @@ title: Data Model Code
 
 Below is the solution for the complete exercise.
 
-```commandline
+```
 jshell> client.tableOperations().create("GothamPD");
 ```
 Create a row for Batman
-```commandline
+```
 jshell> Mutation mutation1 = new Mutation("id0001");
 mutation1 ==> org.apache.accumulo.core.data.Mutation@1
 
@@ -18,7 +18,7 @@ jshell> mutation1.put("hero","wearsCape?", "true");
 ```
 
 Create a row for Robin
-```commandline
+```
 jshell> Mutation mutation2 = new Mutation("id0002");
 mutation2 ==> org.apache.accumulo.core.data.Mutation@1
 
@@ -28,7 +28,7 @@ jshell> mutation2.put("hero","wearsCape?", "true");
 ```
 
 Create a row for Joker
-```commandline
+```
 jshell> Mutation mutation3 = new Mutation("id0003");
 mutation3 ==> org.apache.accumulo.core.data.Mutation@1
 
@@ -40,7 +40,7 @@ jshell> mutation3.put("villain","wearsCape?", "false");
 Create a BatchWriter to the GothamPD table and add your mutations to it.
 Once the BatchWriter is closed by the try-with-resources, data will be available to scans.
 
-```commandline
+```
 jshell> try (BatchWriter writer = client.createBatchWriter("GothamPD")) {
    ...>   writer.addMutation(mutation1);
    ...>   writer.addMutation(mutation2);
@@ -52,7 +52,7 @@ Read and print all rows of the "GothamPD" table. Try-with-resources will close f
 
 Note: A Scanner is an extension of ```java.lang.Iterable``` so it will traverse through the table.
 
-```commandline
+```
 jshell> try (ScannerBase scan = client.createScanner("GothamPD", Authorizations.EMPTY)) {
    ...>   System.out.println("Gotham Police Department Persons of Interest:");
    ...>     for (Map.Entry<Key, Value> entry : scan) {

--- a/tour/data-model.md
+++ b/tour/data-model.md
@@ -19,7 +19,7 @@ The **value** is where the actual data is stored. For brevity, we often refer to
 column as the family, qualifier, and visibility.
 
 Take a closer look at the Mutation object created in the first exercise:
-```commandline
+```java
 Mutation mutation1 = new Mutation("id0001");
 mutation1.put("hero","alias", "Batman");
 ```

--- a/tour/getting-started.md
+++ b/tour/getting-started.md
@@ -8,14 +8,14 @@ Accumulo cluster you can use [fluo-uno] to set up a single node instance for use
 Once you have an instance up and running, start the Accumulo JShell interface by typing the command
 below. The '$' represents the system prompt.
 
-```commandline
+```shell
 $ accumulo jshell
 ```
 
 This will present you with a Java JShell interface with the required Accumulo libraries pre-loaded
 and a working Accumulo ```client``` object.
 
-```commandline
+```
 Preparing JShell for Apache Accumulo
 
 Use 'client' to interact with Accumulo
@@ -30,7 +30,7 @@ JShell has a few commands that can be helpful.
 
 `/imports` lists the currently loaded imports in the JShell session.
 
-```commandline
+```
 jshell> /imports
 |    import java.io.*
 |    import java.math.*
@@ -67,7 +67,7 @@ jshell> /imports
 
 `/vars` will display all currently defined variables.
 
-```commandline
+```
 jshell> /vars
 |    URL clientPropUrl = file:<path_to_accumulo_dir>/conf/accumulo-client.properties
 |    AccumuloClient client = org.apache.accumulo.core.clientImpl.ClientContext@7cbee484
@@ -83,7 +83,7 @@ jshell> /vars
 
 For example:
 
-```commandline
+```
 jshell> var x = 12;
 x ==> 12
 

--- a/tour/ranges-splits.md
+++ b/tour/ranges-splits.md
@@ -4,7 +4,7 @@ title: Ranges and Splits
 
 A [Range] is a specified group of `Key`s. There are many ways to create a `Range`.  Here are a few examples:
 
-```commandline
+```java
 Range r1 = new Range(startKey, endKey);  // Creates a range from startKey inclusive to endKey inclusive.
 Range r2 = new Range(row);               // Creates a range that covers an entire row.
 Range r3 = new Range(startRow, endRow);  // Creates a range from startRow inclusive to endRow inclusive.
@@ -13,7 +13,7 @@ Range r3 = new Range(startRow, endRow);  // Creates a range from startRow inclus
 A `Scanner` by default will scan all ```Key```'s in a table but this can be inefficient. It is a good practice to
 set a range on a Scanner.
 
-```commandline
+```java
 scanner.setRange(new Range("id0000", "id0010"));  // returns rows from id0000 to id0010
 ```
 

--- a/tour/using-iterators.md
+++ b/tour/using-iterators.md
@@ -8,7 +8,7 @@ aggregation operations on data during scans and during compactions.
 
 Let's begin by adding some data for our hero's recording recent crime-stopping statistics.
 
-```commandlne
+```
 jshell> client.tableOperations().create("GothamCrimeStats");
 
 jshell> Mutation mutation1 = new Mutation("id0001");
@@ -37,7 +37,7 @@ jshell> try (BatchWriter writer = client.createBatchWriter("GothamCrimeStats")) 
 
 Let's scan to see the data.
 
-```commandline
+```
 jshell> try (ScannerBase scan = client.createScanner("GothamCrimeStats", Authorizations.EMPTY)) {
    ...>   System.out.println("Gotham Police Department Crime Statistics:");
    ...>   for(Map.Entry<Key, Value> entry : scan) {
@@ -55,14 +55,14 @@ a set number of past entries to display). The iterator is named `vers`.
 
 To simplify, we will import some additional packages to save some typing.
 
-```commandline
+```
 jshell> import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 jshell> client.tableOperations().removeIterator("GothamCrimeStats", "vers", EnumSet.allOf(IteratorScope.class));
 ```
 
 Now let's scan again.
 
-```commandline
+```
 jshell> try (ScannerBase scan = client.createScanner("GothamCrimeStats", Authorizations.EMPTY)) {
    ...>   System.out.println("Gotham Police Department Crime Statistics:");
    ...>   for(Map.Entry<Key, Value> entry : scan) {
@@ -85,7 +85,7 @@ You will now see ALL entries added to the table.
 Instead of seeing a daily history, let's instead keep a running total of captured villains.
 A `summingcombiner` can be used to accomplish this.
 
-```commandline
+```
 jshell> import org.apache.accumulo.core.iterators.user.SummingCombiner;
 jshell> import org.apache.accumulo.core.iterators.LongCombiner
 ```
@@ -94,7 +94,7 @@ Create an IteratorSetting object. Set the encoding type and indicate the columns
 Also, it is a good idea to check for any iterator conflicts prior to attaching the iterator to the
 table.
 
-```commandline
+```
 jshell> IteratorSetting scSetting = new IteratorSetting(30, "sum", SummingCombiner.class);
 jshell> LongCombiner.setEncodingType(scSetting, LongCombiner.Type.STRING);
 jshell> scSetting.addOption("columns", "hero:villainsCaptured");
@@ -104,7 +104,7 @@ jshell> client.tableOperations().attachIterator("GothamCrimeStats", scSetting);
 
 Let's scan again and see what results we get.
 
-```commandline
+```
 jshell> try ( org.apache.accumulo.core.client.Scanner scan = client.createScanner("GothamCrimeStats", Authorizations.EMPTY)) {
    ...>   for(Map.Entry<Key, Value> entry : scan) {
    ...>     System.out.printf("Key : %-52s  Value : %s\n", entry.getKey(), entry.getValue());
@@ -118,7 +118,7 @@ Key : id0002 hero:villainsCaptured [] 1654699186182 false   Value : 3
 
 Adding additional statistics will result in a continual update of the relevant statistic.
 
-```commandline
+```
 jshell> mutation1 = new Mutation("id0001");
 jshell> mutation1.put("hero", "villainsCaptured", "4");
 jshell> mutation2 = new Mutation("id0002");


### PR DESCRIPTION
This PR fixes and improves a bunch of code blocks throughout the site.

For some reason `commandline` was used a lot in the code blocks but does not exist in the code highlighter we use, [rouge](https://rouge.jneen.net/v4.1.3/sed/). So a lot if blocks ended up looking like this:
![Screenshot from 2023-09-15 09-36-27](https://github.com/apache/accumulo-website/assets/47725857/fd6b003d-26c1-424a-93b7-f360c55f5d79)
And after being fixed they look correct:
![Screenshot from 2023-09-15 09-33-58](https://github.com/apache/accumulo-website/assets/47725857/bcaad83a-feda-4484-a2e6-fa08fc186f15)

I added the `console` language to a lot of blocks because I think it looks better.
Here is a code block without a language specified:
![Screenshot from 2023-09-15 11-03-04](https://github.com/apache/accumulo-website/assets/47725857/1e3bebe8-d5dd-47d2-9db8-5c52cafde3dc)
And here is the same code block with the `console` language specified.
![Screenshot from 2023-09-15 11-03-54](https://github.com/apache/accumulo-website/assets/47725857/70c89885-503f-44c4-9df4-9ddfed1199f6)
