### PR TITLE
Bump ruby version in github actions script

### DIFF
--- a/.github/workflows/jekyll.yaml
+++ b/.github/workflows/jekyll.yaml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
+        ruby-version: 3.2.2
     - name: Cache gems
       uses: actions/cache@v3
       with:


### PR DESCRIPTION
It looks like the build is failing with:
```
  bundle exec jekyll build
  shell: /usr/bin/bash -e {0}
  ruby 2.6.10p210 (2022-04-12 revision 67958) [x86_64-linux]
  ERROR:  Error installing bundler:
	  The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.4.22. Try installing it with `gem install bundler -v 2.4.22`
	  bundler requires Ruby version >= 3.0.0. The current ruby version is 2.6.10.210.
```
This PR moves to the version found in the Dockerfile, 3.2.2