### PR TITLE
Fix broken link

### DIFF
--- a/pages/how-to-contribute.md
+++ b/pages/how-to-contribute.md
@@ -72,7 +72,7 @@ For more information, see the [contributor guide](/contributors-guide/).
 [confluence]: https://cwiki.apache.org/confluence/display/ACCUMULO/Apache+Accumulo+Home
 [contact]: /contact-us/
 [a]: https://github.com/apache/accumulo
-[ac]: https://github.com/apache/accumulo/blob/main/CONTRIBUTING.md
+[ac]: https://github.com/apache/accumulo/blob/main/.github/CONTRIBUTING.md
 [ai]: https://github.com/apache/accumulo/issues
 [w]: https://github.com/apache/accumulo-website
 [wc]: https://github.com/apache/accumulo-website/blob/main/CONTRIBUTING.md


### PR DESCRIPTION
When clicking on the `Contribute` link for the Core Project under the Accumulo Repositories list, the link presents a 404 error. This PR updates the link to point to the proper page.