### PR TITLE
Stop dropdown menu from being cut off

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -49,7 +49,7 @@
           <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
             <img alt="Apache Software Foundation" src="https://www.apache.org/foundation/press/kit/feather.svg" width="15"/>
           </a>
-          <ul class="dropdown-menu">
+          <ul class="dropdown-menu dropdown-menu-end">
             <li><a class="dropdown-item" href="https://www.apache.org">Apache Homepage <span class="fa-solid fa-up-right-from-square"></span></a></li>
             <li><a class="dropdown-item" href="https://www.apache.org/licenses/">License <span class="fa-solid fa-up-right-from-square"></span></a></li>
             <li><a class="dropdown-item" href="https://www.apache.org/foundation/sponsorship">Sponsorship <span class="fa-solid fa-up-right-from-square"></span></a></li>


### PR DESCRIPTION
This change make the rightmost dropdown menu in the navbar open to the left instead of the right. Before this change, if the screen was not wide enough, some of the dropdown options would get cut off by the side of the page:
![Screenshot from 2024-07-19 10-49-14](https://github.com/user-attachments/assets/021713d5-f39d-41ef-82e4-db8c19275b50)

Now it looks like this:
![Screenshot from 2024-07-19 10-49-39](https://github.com/user-attachments/assets/352188ab-0c4b-4b55-a41d-c4fa5014b838)

I verified that the mobile view still behaves correctly with this change too.