### PR TITLE
Modify config to include _docs-4 in generated site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,9 @@ collections:
   docs-2:
     output: true
     permalink: "/docs/2.x/:path"
+  docs-4:
+    output: true
+    permalink: "/docs/4.x/:path"
 
 defaults:
   -
@@ -75,6 +78,20 @@ defaults:
       latest_release: "2.1.3"
       javadoc_version: "2.1.3"
       docs_baseurl: "/docs/2.x"
+      javadoc_base: "https://www.javadoc.io/static/org.apache.accumulo"
+      skiph1fortitle: "true"
+      gh_branch: "main"
+  -
+    scope:
+      path: ""
+      type: "docs-4"
+    values:
+      layout: "docs-4"
+      title_prefix: "Accumulo Documentation - "
+      version: "4.x"
+      latest_release: "4.0.0-SNAPSHOT"
+      javadoc_version: "4.0.0-SNAPSHOT"
+      docs_baseurl: "/docs/4.x"
       javadoc_base: "https://www.javadoc.io/static/org.apache.accumulo"
       skiph1fortitle: "true"
       gh_branch: "main"

--- a/_docs-4/getting-started/quickstart.md
+++ b/_docs-4/getting-started/quickstart.md
@@ -4,7 +4,7 @@ category: getting-started
 order: 1
 skip_doc_h1: true
 ---
-# User Manual (2.x and 3.x)
+# User Manual (4.x)
 
 Starting with Accumulo 2.0, the user manual now lives on the website as a series
 of web pages. Previously, it was one large pdf document that was only generated

--- a/_layouts/docs-4.html
+++ b/_layouts/docs-4.html
@@ -1,0 +1,58 @@
+---
+layout: default
+skiph1fortitle: true
+---
+
+<div class="alert alert-danger" style="margin-bottom: 0px;" role="alert">
+  This is a <strong>draft</strong> user guide for a future release of Accumulo 4.0.0!<br>
+</div>
+
+<div class="row">
+  <div class="col-md-3">
+    <div class="accordion sticky-top" id="myAccordion" style="top: 100px;">
+      {% assign mydocs = site.docs-4 | group_by: 'category' %}
+      {% assign categories = "getting-started,development,security,configuration,administration,troubleshooting" | split: "," %}
+      {% for pcat in categories %}
+        {% for dcat in mydocs %}
+          {% if pcat == dcat.name %}
+            <div class="accordion-item">
+              <div class="accordion-header fs-5 fw-bold" id="heading{{ pcat }}">
+                <button class="accordion-button {% if pcat != page.category %}collapsed{% endif %}" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{ pcat }}" aria-expanded="{% if pcat == page.category %}true{% else %}false{% endif %}" aria-controls="collapse{{ pcat }}">
+                  {{ pcat | capitalize | replace: "-", " " }}
+                </button>
+              </div>
+              <div id="collapse{{pcat}}" class="accordion-collapse collapse{% if pcat == page.category %} show{% endif %}" aria-labelledby="heading{{ pcat }}" data-bs-parent="#myAccordion">
+                <div class="accordion-body">
+                  {% assign items = dcat.items | sort: 'order' %}
+                  {% for item in items %}
+                    <div class="row{% if page.title == item.title %} selected{% endif %}"><a href="{{ item.url }}">{{ item.title }}</a></div>
+                  {% endfor %}
+                </div>
+              </div>
+            </div>
+          {% endif %}
+        {% endfor %}
+      {% endfor %}
+    </div>
+  </div>
+  <div class="col-md-9">
+    {% if page.category %}
+    <p>Accumulo {{ page.version }} Documentation &gt;&gt; {{ page.category | capitalize | replace: "-", " " }} &gt;&gt; {{ page.title }}</p>
+    {% endif %}
+    {% unless page.skip_doc_h1 %}
+    <div class="row mt-4">
+      <div class="col-md-12 d-flex justify-content-between">
+        <h1>{{ page.title }}</h1>
+        <a href="https://github.com/apache/accumulo-website/edit/main/{{ page.path }}" role="button"><span class="fa-solid fa-pen-to-square"></span> <small>Edit this page</small></a>
+      </div>
+    </div>
+    {% endunless %}
+    {{ content }}
+    <div class="row mt-4">
+      <div class="col-md-12 d-flex justify-content-between">
+        <strong>Find documentation for all releases in the <a href="{{ site.baseurl }}/docs-archive">archive</strong>
+        <a href="https://github.com/apache/accumulo-website/edit/main/{{ page.path }}" role="button"><span class="fa-solid fa-pen-to-square"></span> <small>Edit this page</small></a>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
These changes will include the _docs-4 directory in the generated site at `docs/4.x`. All pages will have a warning at the top to tell the reader that these are draft docs for an upcoming 4.0 release. These pages are not listed in the `Documentation` drop down menu.