### PR TITLE
Improve development dockerfile and associated readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM ruby:3.2.2-slim-bullseye AS base
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt update && apt install -y --no-install-recommends \
     build-essential \
     git \
     curl \
@@ -26,8 +26,8 @@ RUN gem update --system \
   && bundle install \
   && gem cleanup
 
-ENV HOST=0.0.0.0 \
-    PORT=4000
+ENV HOST=0.0.0.0
+ENV PORT=4000
 
 EXPOSE $PORT
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # making updates to the accumulo website without requiring the dev
 # to maintain a local ruby development environment.
 
-FROM ruby:3.2.2-slim-bullseye as base
+FROM ruby:3.2.2-slim-bullseye AS base
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
@@ -17,16 +17,17 @@ WORKDIR /mnt/workdir
 # from the mounted directory. But that's not available during the
 # docker build, so we need to copy them in to pre-install the Gems
 
-COPY Gemfile ./Gemfile
-COPY Gemfile.lock ./Gemfile.lock
+COPY Gemfile Gemfile.lock ./
 
 # Gems will be installed under GEM_HOME which is set by the ruby image.
 # See https://hub.docker.com/_/ruby for details.
 
-RUN gem update --system && bundle install && gem cleanup
+RUN gem update --system \
+  && bundle install \
+  && gem cleanup
 
-ENV HOST=0.0.0.0
-ENV PORT=4000
+ENV HOST=0.0.0.0 \
+    PORT=4000
 
 EXPOSE $PORT
 

--- a/README.md
+++ b/README.md
@@ -110,10 +110,6 @@ Jekyll will print a local URL where the site can be viewed (usually,
 ### Testing using Docker environment 
 
 A containerized development environment can be built using the local
-Dockerfile.
-
-
-A containerized development environment can be built using the local
 Dockerfile. You can build it with the following command:
 
 ```bash
@@ -123,7 +119,8 @@ docker build -t webdev .
 This action will produce a `webdev` image, with all the website's build
 prerequisites preinstalled. When a container is run from this image, it
 will perform a `jekyll serve` command with the polling option enabled,
-so that changes you make locally will be immediately reflected.
+so that changes you make locally will be immediately reflected after
+reloading the page in your browser.
 
 When you run a container using the webdev image, your current working
 directory will be mounted, so that any changes made by the build inside
@@ -137,19 +134,21 @@ docker run -d -v "$PWD":/mnt/workdir -p 4000:4000 webdev
 While this container is running, you will be able to review the rendered website
 in your local browser at [http://127.0.0.1:4000/](http://127.0.0.1:4000/).
 
-
 Shell access can be obtained by overriding the default container command.
 
 This is useful for adding new gems, or modifying the Gemfile.lock for updating
 existing dependencies.
 
-When using shell access the local directory must be mounted to ensure
+When using shell access, the local directory must be mounted to ensure
 the Gemfile and Gemfile.lock updates are reflected in your local
 environment so you can create a commit and submit a PR.
 
 ```bash
 docker run -v "$PWD":/mnt/workdir -it webdev /bin/bash
 ```
+
+You may need to manually delete the `_site` or `.jekyll-cache` directories if
+they already exist and are causing issues with the build.
 
 ## Publishing
 


### PR DESCRIPTION
* breaks some commands into individual lines to make future maintenance less disruptive
* use uppercase `AS` in dockerfile. There was a warning regarding inconsistent case
* improve readme with a pitfall that I ran into
* remove duplicate line from readme and empty lines