### PR TITLE
Add Robert Kurc to Contributors

### DIFF
--- a/pages/people.md
+++ b/pages/people.md
@@ -172,6 +172,7 @@ GitHub also has a [contributor list][github-contributors] based on commits.
 | Randeep Singh       |                                                                   | [ET][ET]              |
 | Ravi Mutyala        | [Hortonworks][HORTONWORKS]                                        | [CT][CT]              |
 | Richard Eggert II   | [MasterPeace Solutions, Ltd][MASTERPEACE]                         | [ET][ET]              |
+| Robert Kurc         |                                                                   | [ET][ET]              |
 | Russell Carter Jr   | [Arctic Slope Regional Corp.][ASRC]                               | [ET][ET]              |
 | Ryan Fishel         | [Cloudera][CLOUDERA]                                              |                       |
 | Ryan Leary          |                                                                   |                       |


### PR DESCRIPTION
I contributed to the Accumulo Proxy project. I worked on PR [#84 ](https://github.com/apache/accumulo-proxy/pull/84)and [#88](https://github.com/apache/accumulo-proxy/commit/38b80e2020192757581a56e1456db8b0dd23f577).