### PR TITLE
[INFRA] Set up default rulesets for default and release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -20,8 +20,8 @@
 # https://github.com/apache/infrastructure-asfyaml/blob/main/README.md
 
 notifications:
-  commits:      commits@accumulo.apache.org
-  issues:       notifications@accumulo.apache.org
+  commits: commits@accumulo.apache.org
+  issues: notifications@accumulo.apache.org
   pullrequests: notifications@accumulo.apache.org
   jira_options: worklog
 
@@ -38,15 +38,28 @@ github:
     wiki: false
     issues: true
     projects: true
-  dependabot_alerts:  true
+  dependabot_alerts: true
   dependabot_updates: false
 
+  rulesets:
+    - name: "Default Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+          - "rel/*"
+        excludes: []
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true
 staging:
-  profile: ~
-  whoami:  asf-staging
+  profile:
+  whoami: asf-staging
 
 publish:
-  whoami:  asf-site
+  whoami: asf-site
 
 jekyll:
   whoami: main

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -55,7 +55,7 @@ github:
       restrict_deletion: true
       restrict_force_push: true
 staging:
-  profile:
+  profile: ~
   whoami: asf-staging
 
 publish:


### PR DESCRIPTION
This Pull Request enables the repository to conform with the "sane default security settings" of the Apache Software Foundation by configuring a default branch ruleset that protects the default branch and any release branches.

Note that `~DEFAULT_BRANCH` is a GitHub symbolic link to the current default branch (HEAD) of the repository and does not need changing.
If the managing project does not wish to set up these defaults, please close this Pull Request. Alternatively, the project may merge this Pull Request to apply the changes immediately.

If no action is taken, this Pull Request will be automatically merged by the Apache Infrastructure team on **2026-05-29** (14 days from now).

For any further information, please reach us on Slack or at: users@infra.apache.org
